### PR TITLE
fix: resolve nested joint origins via assembly-context proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to **fusion2URDF** are documented here. The format
 follows [Keep a Changelog](https://keepachangelog.com/), and the
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.0.1] - 2026-07-22
+
+- Proxy nested joints with `createForAssemblyContext` so geometry origins resolve.
+- Lift occurrence-local joint origins through the child/parent world pose; do not double-lift world-proxied origins.
+- Remap revolute/prismatic axes as `R_child^T * axis_world` (no defining-assembly pre-multiply).
+- Prefer occurrence `transform2` over the assemblyContext walk for origin fallbacks.
+
 ## [3.0.0] — 2026-05-04
 
 Initial public release.

--- a/DESIGN_GUIDE.md
+++ b/DESIGN_GUIDE.md
@@ -1,4 +1,4 @@
-﻿# Design Guide
+# Design Guide
 
 This guide describes the recommended way to build Fusion 360 robot
 models for the URDF/Xacro exporter.
@@ -252,6 +252,12 @@ Good cases for regular joints:
 Use as-built joints only when the exact joint origin is not important,
 or when you intentionally connect an already-positioned subassembly as a
 single link.
+
+Nested regular joints inside subassemblies (including mirrored mounts)
+are supported: the exporter proxies them into assembly context so Fusion
+exposes the real hinge origin. If a movable joint still falls back to
+the child component pose in the export log, add a `!frame_*` at that
+hinge or recreate the joint. See [Limitations](docs/LIMITATIONS.md).
 
 ### Parent and Child Direction
 

--- a/core/data_types.py
+++ b/core/data_types.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional, Tuple, Any
 # Version
 # ──────────────────────────────────────────────
 
-EXPORTER_VERSION = "3.0.0"
+EXPORTER_VERSION = "3.0.1"
 DESIGN_ROOT_OCCURRENCE_PATH = "__design_root__"
 
 
@@ -227,6 +227,11 @@ class FusionJoint:
     # Phase 1 picks the best available method and converts to meters
     origin_global_m: Vec3 = (0.0, 0.0, 0.0)
     origin_source: str = ""         # Which method gave us the origin
+    # True when origin_global_m / geometry_or_origin_* were read from a
+    # joint proxy created via createForAssemblyContext - Autodesk returns
+    # those points already in root/world coordinates, so Phase 2 must NOT
+    # lift them again through the child occurrence pose.
+    origin_is_world: bool = False
     
     # ── Motion ──
     motion_type: str = ""           # "rigid", "revolute", "slider", "cylindrical", "pin_slot", "planar", "ball"

--- a/core/fusion_extractor.py
+++ b/core/fusion_extractor.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 Fusion Extractor — Extract everything from Fusion 360 into Python dataclasses.
 
 This is the ONLY module that imports adsk.* — all downstream processing
@@ -683,6 +683,120 @@ def _extract_color(appearance):
 # Joint extraction
 # ──────────────────────────────────────────────
 
+# ──────────────────────────────────────────────
+# Joint geometry origin helpers
+# ──────────────────────────────────────────────
+
+def _read_joint_geo_origin_cm(geo, log: Logger = None, context: str = ""):
+    """
+    Read an origin Point3D from Fusion JointGeometry or JointOrigin.
+
+    Nested / regular joints often expose a JointOrigin whose useful point
+    lives on ``.origin``, ``.geometry.origin``, or ``.transform.translation``.
+    Silent AttributeError / RuntimeError used to leave every nested Harper
+    arm joint with a null geometry origin and fall back to the child
+    component pose - bake never fired and links orbited the wrong point.
+    """
+    if geo is None:
+        return None
+
+    where = f"{context}: " if context else ""
+
+    # 1) Direct .origin (JointGeometry and JointOrigin)
+    try:
+        o = getattr(geo, "origin", None)
+        if o is not None:
+            return (float(o.x), float(o.y), float(o.z))
+    except Exception as exc:
+        if log:
+            log.warning(f" {where}failed to read .origin: {exc}")
+
+    # 2) JointOrigin.geometry.origin
+    try:
+        inner = getattr(geo, "geometry", None)
+        if inner is not None:
+            o = getattr(inner, "origin", None)
+            if o is not None:
+                return (float(o.x), float(o.y), float(o.z))
+    except Exception as exc:
+        if log:
+            log.warning(f" {where}failed to read .geometry.origin: {exc}")
+
+    # 3) transform.translation fallback
+    try:
+        xf = getattr(geo, "transform", None)
+        if xf is not None:
+            t = xf.translation
+            return (float(t.x), float(t.y), float(t.z))
+    except Exception as exc:
+        if log:
+            log.warning(f" {where}failed to read .transform.translation: {exc}")
+
+    return None
+
+
+def _proxy_joint_for_assembly_context(
+    joint,
+    defining_comp,
+    root_component,
+    log: Logger,
+    context: str = "",
+):
+    """
+    Return ``(joint_or_proxy, used_proxy)``.
+
+    Joints owned by a nested component (e.g. ``left_arm``) often return
+    null ``geometry`` / ``geometryOrOriginOne`` until proxied into an
+    occurrence via ``createForAssemblyContext``. Autodesk then reports the
+    origin in root/world coordinates.
+    """
+    if joint is None or defining_comp is None or root_component is None:
+        return joint, False
+
+    # Joint already lives on the design root - no proxy needed.
+    try:
+        if defining_comp == root_component:
+            return joint, False
+    except Exception:
+        pass
+
+    where = f"{context}: " if context else ""
+    try:
+        occs = root_component.allOccurrencesByComponent(defining_comp)
+    except Exception as exc:
+        if log:
+            log.warning(
+                f" {where}allOccurrencesByComponent failed: {exc}"
+            )
+        return joint, False
+
+    if not occs or getattr(occs, "count", 0) == 0:
+        return joint, False
+
+    # Prefer the first occurrence; multi-instance designs may need a
+    # smarter match later (path prefix vs occurrenceOne).
+    try:
+        occ = occs.item(0)
+        proxy = joint.createForAssemblyContext(occ)
+        if proxy is not None:
+            if log:
+                occ_name = getattr(occ, "fullPathName", None) or getattr(
+                    occ, "name", "?"
+                )
+                log(
+                    f" {where}proxied joint into assembly context "
+                    f"'{occ_name}' for geometry origin"
+                )
+            return proxy, True
+    except Exception as exc:
+        if log:
+            log.warning(
+                f" {where}createForAssemblyContext failed: {exc}"
+            )
+
+    return joint, False
+
+
 def _extract_all_joints(design, snapshot: FusionSnapshot, log: Logger):
     """Collect all joints from all components — both regular and as-built."""
     
@@ -923,35 +1037,54 @@ def _extract_one_joint(
             return None
     
     # ── Geometry origins — extract ALL methods ──
-    
-    # geometry.origin
-    try:
-        if hasattr(joint, 'geometry') and joint.geometry:
-            if hasattr(joint.geometry, 'origin') and joint.geometry.origin:
-                o = joint.geometry.origin
-                fj.geometry_origin_cm = (o.x, o.y, o.z)
-    except Exception:
-        pass
-    
-    # geometryOrOriginOne
-    try:
-        if hasattr(joint, 'geometryOrOriginOne') and joint.geometryOrOriginOne:
-            geo = joint.geometryOrOriginOne
-            if hasattr(geo, 'origin') and geo.origin:
-                o = geo.origin
-                fj.geometry_or_origin_one_cm = (o.x, o.y, o.z)
-    except Exception:
-        pass
-    
-    # geometryOrOriginTwo
-    try:
-        if hasattr(joint, 'geometryOrOriginTwo') and joint.geometryOrOriginTwo:
-            geo = joint.geometryOrOriginTwo
-            if hasattr(geo, 'origin') and geo.origin:
-                o = geo.origin
-                fj.geometry_or_origin_two_cm = (o.x, o.y, o.z)
-    except Exception:
-        pass
+    # Nested regular joints (Harper arms) often return null geometry until
+    # the joint is proxied into an occurrence via createForAssemblyContext.
+    # Autodesk then reports origins in root/world coordinates.
+    geo_joint, used_proxy = _proxy_joint_for_assembly_context(
+        joint, defining_comp, root_component, log, context
+    )
+    fj.origin_is_world = bool(used_proxy)
+
+    fj.geometry_origin_cm = _read_joint_geo_origin_cm(
+        _safe_fusion_attr(geo_joint, "geometry", None, log, context),
+        log,
+        f"{context} geometry",
+    )
+    fj.geometry_or_origin_one_cm = _read_joint_geo_origin_cm(
+        _safe_fusion_attr(geo_joint, "geometryOrOriginOne", None, log, context),
+        log,
+        f"{context} geometryOrOriginOne",
+    )
+    fj.geometry_or_origin_two_cm = _read_joint_geo_origin_cm(
+        _safe_fusion_attr(geo_joint, "geometryOrOriginTwo", None, log, context),
+        log,
+        f"{context} geometryOrOriginTwo",
+    )
+
+    # If the native (non-proxy) joint had local-frame origins that the proxy
+    # missed, try the native joint as a fallback - but mark as not-world.
+    if (
+        fj.geometry_origin_cm is None
+        and fj.geometry_or_origin_one_cm is None
+        and fj.geometry_or_origin_two_cm is None
+        and geo_joint is not joint
+    ):
+        fj.origin_is_world = False
+        fj.geometry_origin_cm = _read_joint_geo_origin_cm(
+            _safe_fusion_attr(joint, "geometry", None, log, context),
+            log,
+            f"{context} geometry(native)",
+        )
+        fj.geometry_or_origin_one_cm = _read_joint_geo_origin_cm(
+            _safe_fusion_attr(joint, "geometryOrOriginOne", None, log, context),
+            log,
+            f"{context} geometryOrOriginOne(native)",
+        )
+        fj.geometry_or_origin_two_cm = _read_joint_geo_origin_cm(
+            _safe_fusion_attr(joint, "geometryOrOriginTwo", None, log, context),
+            log,
+            f"{context} geometryOrOriginTwo(native)",
+        )
     
     # occurrenceOne transform variants
     if occ_one:
@@ -969,8 +1102,15 @@ def _extract_one_joint(
         except Exception:
             pass
         
-        # Global via assemblyContext chain
-        fj.occ_one_global_cm, fj.occ_one_context_depth = _walk_assembly_context(occ_one)
+        # Global position: prefer transform2 (Fusion's composed world pose).
+        # The assemblyContext translation-only walk silently drops nested
+        # rotations - wrong for mirrored sub-asms (Harper right arm) and
+        # produces metre-scale mesh bake offsets when used as joint origin.
+        if fj.occ_one_transform2_cm is not None:
+            fj.occ_one_global_cm = fj.occ_one_transform2_cm
+            fj.occ_one_context_depth = _count_chain_depth(occ_one)
+        else:
+            fj.occ_one_global_cm, fj.occ_one_context_depth = _walk_assembly_context(occ_one)
     
     # occurrenceTwo transforms
     if occ_two:
@@ -980,14 +1120,40 @@ def _extract_one_joint(
                 fj.occ_two_transform_cm = (t.x, t.y, t.z)
         except Exception:
             pass
-        
-        fj.occ_two_global_cm, fj.occ_two_context_depth = _walk_assembly_context(occ_two)
+
+        try:
+            if hasattr(occ_two, 'transform2') and occ_two.transform2:
+                t = occ_two.transform2.translation
+                # Store via walk fallback path using transform2 when present
+                fj.occ_two_global_cm = (t.x, t.y, t.z)
+                fj.occ_two_context_depth = _count_chain_depth(occ_two)
+            else:
+                fj.occ_two_global_cm, fj.occ_two_context_depth = _walk_assembly_context(occ_two)
+        except Exception:
+            fj.occ_two_global_cm, fj.occ_two_context_depth = _walk_assembly_context(occ_two)
     
     # ── Pick best origin (global, meters) ──
     fj.origin_global_m, fj.origin_source = _pick_joint_origin(fj)
-    
+    if fj.origin_is_world and fj.origin_source in (
+        "geometry.origin",
+        "geometryOrOriginOne",
+        "geometryOrOriginTwo",
+    ):
+        fj.origin_source = f"{fj.origin_source}_world"
+
     # ── Motion type ──
     _extract_joint_motion(joint, fj)
+
+    if (
+        fj.origin_source in ("occ_one_transform2", "occ_one_global", "occ_one_transform", "none")
+        and fj.motion_type in ("revolute", "slider", "cylindrical", "pin_slot", "ball")
+    ):
+        log.warning(
+            f" {context} '{name}': no Fusion joint geometry origin - "
+            f"falling back to child component pose ({fj.origin_source}). "
+            f"Mesh bake cannot rebase this link; add a !frame_* at the hinge "
+            f"or recreate the joint so geometryOrOriginOne exports."
+        )
     
     # ── Log ──
     tag = source.upper()
@@ -1010,7 +1176,8 @@ def _extract_one_joint(
     if fj.occ_two_global_cm:
         log(f"    occ2.global:    ({fj.occ_two_global_cm[0]:.4f}, {fj.occ_two_global_cm[1]:.4f}, {fj.occ_two_global_cm[2]:.4f}) cm")
     
-    log(f"    → origin_global: ({fj.origin_global_m[0]:.6f}, {fj.origin_global_m[1]:.6f}, {fj.origin_global_m[2]:.6f}) m [via {fj.origin_source}]")
+    world_tag = " [world]" if fj.origin_is_world else ""
+    log(f" -> origin_global: ({fj.origin_global_m[0]:.6f}, {fj.origin_global_m[1]:.6f}, {fj.origin_global_m[2]:.6f}) m [via {fj.origin_source}]{world_tag}")
     log(f"    motion: {fj.motion_type}, axis: ({fj.axis_vector[0]:.3f}, {fj.axis_vector[1]:.3f}, {fj.axis_vector[2]:.3f})")
     
     if fj.has_rotation_limits:
@@ -1053,21 +1220,27 @@ def _walk_assembly_context(occ):
 
 def _pick_joint_origin(fj: FusionJoint):
     """
-    Pick the best available origin and convert to global meters.
-    
+    Pick the best available origin and convert to meters.
+
     Priority:
-      1. geometry.origin — most reliable (regular joints, some as-built)
-      2. geometryOrOriginOne.origin — fallback for regular joints
-      3. occ_one_global via assemblyContext chain — universal fallback
-      4. occ_one_transform — last resort
-    
-    Note: geometry.origin and geometryOrOriginOne.origin are in the
-    DEFINING COMPONENT's coordinate frame. For joints defined in the
-    root component, this IS global. For joints defined inside a
-    sub-assembly, the coordinates are assembly-local.
-    
-    We store the raw value here and let Phase 2 (robot_model) handle
-    the frame conversion once the assembly hierarchy is known.
+      1. geometry.origin - often available; treated as defining-assembly
+         local by Phase 2 when the joint is nested (legacy lift).
+      2. geometryOrOriginOne.origin - occurrenceOne-local; Phase 2 lifts
+         this through the child occurrence's world pose (preferred for
+         nested / mirrored sub-assemblies).
+      3. occ_one_transform2 - Fusion's composed world pose (preferred
+         over the translation-only assemblyContext walk)
+      4. occ_one_global via assemblyContext chain - last global fallback
+      5. occ_one_transform - last resort
+
+    Note: ``geometryOrOriginOne/Two.origin`` are in the *mated
+    occurrence's* component-local frame (Autodesk forum / API practice),
+    NOT the defining assembly frame. Phase 2
+    (``_compute_joint_global_origin``) therefore prefers lifting those
+    through the occurrence world pose. ``geometry.origin`` remains the
+    Phase-1 pick for backwards-compatible snapshots that lack the
+    per-side origin fields; Phase 2 still upgrades to occ1/occ2 when
+    those fields are present.
     """
     if fj.geometry_origin_cm:
         x, y, z = fj.geometry_origin_cm
@@ -1076,6 +1249,10 @@ def _pick_joint_origin(fj: FusionJoint):
     if fj.geometry_or_origin_one_cm:
         x, y, z = fj.geometry_or_origin_one_cm
         return (cm_to_m(x), cm_to_m(y), cm_to_m(z)), "geometryOrOriginOne"
+
+    if fj.occ_one_transform2_cm:
+        x, y, z = fj.occ_one_transform2_cm
+        return (cm_to_m(x), cm_to_m(y), cm_to_m(z)), "occ_one_transform2"
     
     if fj.occ_one_global_cm:
         x, y, z = fj.occ_one_global_cm

--- a/core/package_generator.py
+++ b/core/package_generator.py
@@ -876,7 +876,7 @@ def _load_template(name: str) -> str:
     pkg_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     path = os.path.join(pkg_root, "templates", "sections", name)
     if os.path.exists(path):
-        with open(path, 'r') as f:
+        with open(path, 'r', encoding='utf-8') as f:
             return f.read().strip()
     return ""
 

--- a/core/robot_model.py
+++ b/core/robot_model.py
@@ -26,7 +26,7 @@ from .data_types import (
     InertiaTensor, Vec3, RPY, RigidGroupInfo,
     DESIGN_ROOT_OCCURRENCE_PATH,
 )
-from ..utils import Logger, clean_name
+from ..utils import Logger, clean_name, cm_to_m
 
 
 # ──────────────────────────────────────────────
@@ -2120,25 +2120,47 @@ def _build_joints(
                 f"({before[0]:.6f}, {before[1]:.6f}, {before[2]:.6f}) → "
                 f"({origin_xyz[0]:.6f}, {origin_xyz[1]:.6f}, {origin_xyz[2]:.6f}) m")
 
-        # Joint axis — Fusion's ``rotationAxisVector`` is documented as
-        # "world space" but empirically it's in the JOINT'S DEFINING
-        # COMPONENT'S frame (same as the origin source — the gripper's
-        # joint axes came out wrong when the gripper sub-asm was
-        # mounted into Assem1 with a non-identity rotation).  Lift to
-        # true world frame by rotating through the defining assembly's
-        # ``global_rotation`` (no-op when the joint is defined in the
-        # design root — global_rotation is identity there), THEN rotate
-        # into the joint's local frame with R_child_worldᵀ.
+        # Joint axis - Fusion's ``rotationAxisVector`` /
+        # ``slideDirectionVector`` are in the *root component* (design /
+        # world) context. Autodesk documents this, and Harper's mirrored
+        # right arm confirms it: extracted axes are world-tilted, and
+        # ``R_child^T * axis_world`` recovers clean +/-X/Y/Z in the joint
+        # frame.
+        #
+        # An earlier revision treated the vector as defining-component
+        # local and pre-multiplied ``assemblies[defining].global_rotation``.
+        # That DOUBLE-applied the sub-asm pose on mirrored mounts (right
+        # arm 180 deg about Y) and left thumb/finger axes skewed in the URDF
+        # even though the main arm joints looked fine (identity left_arm
+        # made the extra lift a no-op there).
+        #
+        # URDF ``<axis>`` is in the joint frame (= child link at theta = 0):
+        # axis_urdf = R_child_world^T * axis_world
         if urdf_type in ("revolute", "prismatic", "continuous"):
-            axis_in_defining = fj.axis_vector
-            defining = edge.defining_component
-            if (defining and defining in assemblies
-                    and defining != snapshot.design_name_clean):
-                R_defining_world = assemblies[defining].global_rotation
-                axis_world = _rotate_vec3_by_mat3(axis_in_defining, R_defining_world)
-            else:
-                axis_world = axis_in_defining
-            axis_local = _rotate_vec3_by_mat3(axis_world, _mat3_transpose(r_child_world))
+            axis_world = fj.axis_vector
+            axis_local = _rotate_vec3_by_mat3(
+                axis_world, _mat3_transpose(r_child_world)
+            )
+            # Normalize - Fusion vectors are unit, but mirrored remaps can
+            # drift by ~1e-15 and consumers expect ||axis|| = 1.
+            axis_norm = math.sqrt(
+                axis_local[0] ** 2 + axis_local[1] ** 2 + axis_local[2] ** 2
+            )
+            if axis_norm > 1e-12:
+                axis_local = (
+                    axis_local[0] / axis_norm,
+                    axis_local[1] / axis_norm,
+                    axis_local[2] / axis_norm,
+                )
+            if any(
+                abs(axis_local[i] - axis_world[i]) > 1e-6 for i in range(3)
+            ):
+                log(
+                    f" {edge.joint_name}: axis remapped world -> joint/child "
+                    f"frame: ({axis_world[0]:.3f}, {axis_world[1]:.3f}, "
+                    f"{axis_world[2]:.3f}) -> ({axis_local[0]:.3f}, "
+                    f"{axis_local[1]:.3f}, {axis_local[2]:.3f})"
+                )
         else:
             axis_local = fj.axis_vector
 
@@ -2186,6 +2208,47 @@ def _build_joints(
     log(f"  Built {len(model.joints)} joints")
 
 
+def _occurrence_world_pose(
+    occ_path: str, snapshot: FusionSnapshot
+) -> Optional[Tuple[Tuple[float, ...], Vec3]]:
+    """Return ``(R_world, t_world)`` for an occurrence, or None if missing."""
+    if not occ_path:
+        return None
+    occ = snapshot.occurrences.get(occ_path)
+    if occ is None:
+        return None
+    R = _global_rotation_for_occurrence(occ_path, snapshot)
+    t = occ.global_position
+    return R, t
+
+
+def _lift_point_by_occurrence(
+    local_cm: Optional[Vec3],
+    occ_path: str,
+    snapshot: FusionSnapshot,
+) -> Optional[Vec3]:
+    """Lift a point from an occurrence's local frame into world meters.
+
+    Autodesk's documented approach for joint world coordinates:
+    ``geometryOrOriginOne/Two.origin`` lives in that occurrence's
+    component-local frame; multiply by the occurrence's full root
+    transform (``transform2`` / ``global_position``) to get world.
+
+    Using the *defining assembly* frame instead - the previous
+    behaviour - mis-places pivots inside nested / mirrored sub-asms
+    (e.g. a right arm mounted with 180 deg roll) and produces metre-scale
+    mesh bake offsets that explode the robot when joints move.
+    """
+    if local_cm is None:
+        return None
+    pose = _occurrence_world_pose(occ_path, snapshot)
+    if pose is None:
+        return None
+    R, t = pose
+    local_m = (cm_to_m(local_cm[0]), cm_to_m(local_cm[1]), cm_to_m(local_cm[2]))
+    return _vec_add(_rotate_vec3_by_mat3(local_m, R), t)
+
+
 def _compute_joint_global_origin(
     fj: FusionJoint,
     edge: KinematicEdge,
@@ -2193,19 +2256,59 @@ def _compute_joint_global_origin(
     snapshot: FusionSnapshot,
 ) -> Vec3:
     """
-    Compute joint origin in global coordinates.
-    
-    geometry.origin and geometryOrOriginOne are in the DEFINING COMPONENT's
-    local frame. For joints defined inside sub-assemblies, we add the
-    assembly's global offset.
-    
-    Fallback sources (occ_one_global) are already global.
+    Compute joint origin in global (root) coordinates.
+
+    Preference order (Autodesk + nested/mirrored assembly practice):
+
+      0. World-proxied geometry (``origin_is_world`` / ``*_world`` source)
+          - already root-frame from ``createForAssemblyContext``
+      1. geometryOrOriginOne x child occurrence world pose
+      2. geometryOrOriginTwo x parent occurrence world pose
+      3. geometry.origin lifted through the defining sub-assembly pose
+         (legacy path - assembly-local coordinates only)
+      4. ``fj.origin_global_m`` as already stored (occ_one_global etc.)
+
+    (1) is required for designs like Harper's mirrored right arm: an
+    assembly-local ``geometry.origin`` of (0,0,0) lifts to the sub-asm
+    origin and creates metre-scale mesh bake offsets, while
+    ``geometryOrOriginOne`` of (0,0,0) correctly means "joint at the
+    child component origin."
     """
+    # 0) Assembly-context proxy already returned root/world coordinates.
+    # Re-lifting through the child pose would double-apply the sub-asm
+    # transform and put pivots metres away from the hinge.
+    if fj.origin_is_world or str(fj.origin_source).endswith("_world"):
+        return fj.origin_global_m
+
+    # 1) Child-side joint geometry in the child occurrence's local frame.
+    world = _lift_point_by_occurrence(
+        fj.geometry_or_origin_one_cm, edge.child_path, snapshot
+    )
+    if world is not None:
+        return world
+
+    # 2) Parent-side joint geometry in the parent occurrence's local frame.
+    world = _lift_point_by_occurrence(
+        fj.geometry_or_origin_two_cm, edge.parent_path, snapshot
+    )
+    if world is not None:
+        return world
+
     defining = edge.defining_component
     source = fj.origin_source
     raw_origin = fj.origin_global_m  # Already converted to meters in Phase 1
 
-    # Check if origin is assembly-local (from geometry methods)
+    # 3) Occurrence-global fallbacks from Phase 1. Older snapshots used a
+    # translation-only assemblyContext walk for ``occ_one_global``, which
+    # disagrees with transform2 on mirrored nested arms (Harper right arm:
+    # joint at +0.63 m vs child at -0.03 m -> 0.6 m bake). Always prefer
+    # the child occurrence's transform2-backed ``global_position``.
+    if source in ("occ_one_global", "occ_one_transform", "occ_one_transform2"):
+        pose = _occurrence_world_pose(edge.child_path, snapshot)
+        if pose is not None:
+            return pose[1]
+
+    # 4) Legacy: geometry.origin treated as defining-assembly local.
     needs_offset = (
         source in ("geometry.origin", "geometryOrOriginOne", "geometryOrOriginTwo")
         and defining in assemblies
@@ -2214,22 +2317,14 @@ def _compute_joint_global_origin(
 
     if needs_offset:
         # Lift the joint origin from the defining sub-asm's local frame
-        # into world frame.  Earlier this was a translation-only
-        # ``_vec_add(raw_origin, asm_offset)`` which silently dropped
-        # the sub-asm's rotation — fine when the sub-asm sat at world
-        # identity but wrong otherwise (visible on the gripper-on-arm
-        # mount where the gripper sub-asm carries the mount joint's
-        # rotation).  Use the full rigid transform: world = R_asm ·
-        # raw + t_asm.
+        # into world frame. Use the full rigid transform:
+        # world = R_asm * raw + t_asm.
         R_asm = assemblies[defining].global_rotation
         t_asm = assemblies[defining].global_offset
         rotated = _rotate_vec3_by_mat3(raw_origin, R_asm)
         return _vec_add(rotated, t_asm)
 
-    # occ_one_global / occ_one_transform are already global (via assemblyContext)
-    # But occ_one_transform might be local if context_depth==0 for nested joints
-    # occ_one_global should be reliable — it walks assemblyContext chain
-
+    # 5) Root-local geometry.origin / other already-world sources.
     return raw_origin
 
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -16,6 +16,14 @@ If a component origin is wrong but the geometry is otherwise good, add a
 merged link frame and does not export as geometry. This is the preferred fix
 for base frames, wheel centers, sensor frames, mount frames, and tool frames.
 
+Nested regular joints (joints defined inside a subassembly such as an arm)
+often return null `geometry` / `geometryOrOriginOne` until the exporter
+proxies them with `createForAssemblyContext`. Exporter v3.0.1+ does this
+automatically so mesh bake can place the URDF link frame on the real hinge.
+If a movable joint still logs a fallback to `occ_one_transform2`, add a
+`!frame_*` at that hinge or recreate the joint so Fusion exposes a joint
+origin.
+
 If many joints were created around the wrong world orientation, rebuilding the
 small assembly can be faster and safer than trying to patch every joint.
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 Tests for fusion2URDF core helpers.
 
 Run from the PARENT directory of fusion2URDF/:
@@ -358,6 +358,68 @@ def test_steiner_theorem():
     print("  steiner_theorem: PASS")
 
 
+def test_read_joint_geo_origin_cm():
+    """JointGeometry / JointOrigin origins must be read through several
+    Fusion shapes - nested Harper joints previously returned null because
+    only bare ``.origin`` was tried inside a silent ``except``."""
+    from ..core.fusion_extractor import _read_joint_geo_origin_cm
+
+    class _P:
+        def __init__(self, x, y, z):
+            self.x, self.y, self.z = x, y, z
+
+    class _GeoOrigin:
+        def __init__(self):
+            self.origin = _P(1.0, 2.0, 3.0)
+
+    class _JointOriginViaGeometry:
+        @property
+        def origin(self):
+            raise RuntimeError("Fusion InternalValidationError")
+
+        def __init__(self):
+            self.geometry = _GeoOrigin()
+
+    class _ViaTransform:
+        class _T:
+            translation = _P(4.0, 5.0, 6.0)
+
+        @property
+        def origin(self):
+            raise RuntimeError("no origin")
+
+        @property
+        def geometry(self):
+            raise RuntimeError("no geometry")
+
+        transform = _T()
+
+    assert _read_joint_geo_origin_cm(_GeoOrigin()) == (1.0, 2.0, 3.0)
+    assert _read_joint_geo_origin_cm(_JointOriginViaGeometry()) == (1.0, 2.0, 3.0)
+    assert _read_joint_geo_origin_cm(_ViaTransform()) == (4.0, 5.0, 6.0)
+    assert _read_joint_geo_origin_cm(None) is None
+    print(" read_joint_geo_origin_cm: PASS")
+
+
+def test_proxy_joint_skips_root_component():
+    from ..core.fusion_extractor import _proxy_joint_for_assembly_context
+
+    class _Log:
+        def __call__(self, *a, **k):
+            pass
+
+        def warning(self, *a, **k):
+            pass
+
+    root = object()
+    joint = object()
+    out, used = _proxy_joint_for_assembly_context(
+        joint, root, root, _Log(), "test"
+    )
+    assert out is joint and used is False
+    print(" proxy_joint_skips_root_component: PASS")
+
+
 def run_all():
     print("Running tests...\n")
     
@@ -374,6 +436,8 @@ def run_all():
     test_json_serialization()
     test_snapshot_report()
     test_steiner_theorem()
+    test_read_joint_geo_origin_cm()
+    test_proxy_joint_skips_root_component()
     
     print("\n✓ All tests passed!")
 

--- a/tests/test_robot_model.py
+++ b/tests/test_robot_model.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 Tests for Phase 2: Robot Model Builder.
 
 Run from the PARENT directory of fusion2URDF/:
@@ -1925,26 +1925,29 @@ def test_nested_subasm_joint_axis_invariant_under_parent_rotation():
     The axis lives in the joint's local frame — assembly placement
     can't change it.
 
-    Earlier the plugin treated ``fj.axis_vector`` as already in world
-    frame.  Empirically it's in the joint's DEFINING-COMPONENT frame
-    (Fusion's API doc lies — axis came out wrong for nested joints),
-    so we now lift it through the defining assembly's
-    ``global_rotation`` before transforming into the joint's local
-    frame.  This test fakes the same sub-asm at identity vs. rotated
-    and asserts the resulting URDF axes match.
+    Fusion's ``rotationAxisVector`` is in the *root / design* context.
+    When the defining sub-asm is rotated in the parent design, the
+    extracted axis_vector is the world-rotated direction; remapping
+    with ``R_child^T * axis_world`` recovers the link-local axis.
+    This test fakes the same sub-asm at identity vs. Z-90 deg and asserts
+    the resulting URDF axes match.
     """
     import math
     from ..core.data_types import (
         FusionSnapshot, FusionOccurrence, FusionJoint, Transform3D,
     )
-    from ..core.robot_model import build_model
+    from ..core.robot_model import build_model, _rotate_vec3_by_mat3
 
     cz, sz = math.cos(math.pi / 2), math.sin(math.pi / 2)
     rot_z90 = (cz, -sz, 0.0,
                 sz,  cz, 0.0,
                 0.0, 0.0, 1.0)
+    # Link-local axis (what URDF should emit). In world = R_asm * local.
+    axis_local = (0.0, 0.0, 1.0)
 
     def _build(asm_rotation, design_clean_name="ref"):
+        # World-space axis as Fusion would return it for this placement.
+        axis_world = _rotate_vec3_by_mat3(axis_local, asm_rotation)
         snap = FusionSnapshot(
             design_name=design_clean_name, design_name_clean=design_clean_name)
         # The joint sits inside ``inner`` sub-asm — defining_component
@@ -1979,9 +1982,6 @@ def test_nested_subasm_joint_axis_invariant_under_parent_rotation():
                 local_transform=Transform3D(),
             ),
         }
-        # Joint defined inside ``inner``.  Axis vector in inner's
-        # local frame: (0, 0, 1).  Origin in inner's local frame:
-        # (0.10, 0, 0).
         snap.joints = {
             "j": FusionJoint(
                 name="j", defining_component="inner",
@@ -1990,7 +1990,7 @@ def test_nested_subasm_joint_axis_invariant_under_parent_rotation():
                 occurrence_two_path="a v1:1", occurrence_two_clean="a",
                 origin_global_m=(0.10, 0.0, 0.0),
                 origin_source="geometry.origin",
-                axis_vector=(0.0, 0.0, 1.0),  # in inner's local frame
+                axis_vector=axis_world, # root/world context (Fusion)
                 has_rotation_limits=True,
                 rotation_min=-1.0, rotation_max=1.0,
             ),
@@ -2004,7 +2004,7 @@ def test_nested_subasm_joint_axis_invariant_under_parent_rotation():
     j_id = _build(identity).joints["j"]
     j_rot = _build(rot_z90).joints["j"]
 
-    for axis_idx, expected in enumerate((0.0, 0.0, 1.0)):
+    for axis_idx, expected in enumerate(axis_local):
         assert abs(j_id.axis[axis_idx] - expected) < 1e-6, (
             f"identity reference: axis component {axis_idx} got "
             f"{j_id.axis[axis_idx]}, expected {expected}"
@@ -2017,6 +2017,457 @@ def test_nested_subasm_joint_axis_invariant_under_parent_rotation():
         )
 
     print("  nested_subasm_joint_axis_invariant_under_parent_rotation: PASS")
+
+
+def test_mirrored_subasm_axis_not_double_rotated():
+    """Mirrored sub-asm (180 deg about Y) must NOT pre-multiply the Fusion
+    world axis by the defining assembly rotation.
+
+    Harper regression: right-arm thumb MIP axis is world-tilted; lifting
+    through ``R_right_arm`` then ``R_child^T`` left it at ~(+0.39, -0.92)
+    instead of (-1, 0, 0). Correct remap is ``R_child^T * axis_world``.
+    """
+    import math
+    from ..core.data_types import (
+        FusionSnapshot, FusionOccurrence, FusionJoint, Transform3D,
+    )
+    from ..core.robot_model import build_model, _rotate_vec3_by_mat3
+
+    # 180 deg about Y - Harper's right_arm placement.
+    rot_y180 = (-1.0, 0.0, 0.0,
+                 0.0, 1.0, 0.0,
+                 0.0, 0.0, -1.0)
+    # Child link local orientation relative to the arm (non-identity,
+    # like a thumb phalanx). World = R_arm * R_local_in_arm.
+    # Use a 90 deg about Z inside the arm so the child world rotation
+    # differs from the assembly rotation (the failure mode only shows
+    # when R_child != R_defining).
+    cz, sz = math.cos(math.pi / 2), math.sin(math.pi / 2)
+    r_local = (cz, -sz, 0.0,
+               sz, cz, 0.0,
+               0.0, 0.0, 1.0)
+    r_child_world = (
+        rot_y180[0]*r_local[0] + rot_y180[1]*r_local[3] + rot_y180[2]*r_local[6],
+        rot_y180[0]*r_local[1] + rot_y180[1]*r_local[4] + rot_y180[2]*r_local[7],
+        rot_y180[0]*r_local[2] + rot_y180[1]*r_local[5] + rot_y180[2]*r_local[8],
+        rot_y180[3]*r_local[0] + rot_y180[4]*r_local[3] + rot_y180[5]*r_local[6],
+        rot_y180[3]*r_local[1] + rot_y180[4]*r_local[4] + rot_y180[5]*r_local[7],
+        rot_y180[3]*r_local[2] + rot_y180[4]*r_local[5] + rot_y180[5]*r_local[8],
+        rot_y180[6]*r_local[0] + rot_y180[7]*r_local[3] + rot_y180[8]*r_local[6],
+        rot_y180[6]*r_local[1] + rot_y180[7]*r_local[4] + rot_y180[8]*r_local[7],
+        rot_y180[6]*r_local[2] + rot_y180[7]*r_local[5] + rot_y180[8]*r_local[8],
+    )
+    # Desired joint-local axis = -X (thumb flex). World axis as Fusion
+    # returns it = R_child_world * axis_local.
+    axis_local = (-1.0, 0.0, 0.0)
+    axis_world = _rotate_vec3_by_mat3(axis_local, r_child_world)
+
+    snap = FusionSnapshot(design_name="bot", design_name_clean="bot")
+    snap.occurrences = {
+        "right_arm v1:1": FusionOccurrence(
+            full_path="right_arm v1:1", clean_name="right_arm",
+            path_segments=["right_arm"], depth=0, is_subassembly=True,
+            local_transform=Transform3D(rotation=rot_y180),
+            transform2=Transform3D(rotation=rot_y180),
+        ),
+        "right_arm v1:1+palm v1:1": FusionOccurrence(
+            full_path="right_arm v1:1+palm v1:1", clean_name="palm",
+            path_segments=["right_arm", "palm"], depth=1,
+            mass_kg=1.0, body_count=1,
+            global_position=(0.0, 0.0, 0.0),
+            transform2=Transform3D(rotation=rot_y180),
+            local_transform=Transform3D(),
+        ),
+        "right_arm v1:1+thumb v1:1": FusionOccurrence(
+            full_path="right_arm v1:1+thumb v1:1", clean_name="thumb",
+            path_segments=["right_arm", "thumb"], depth=1,
+            mass_kg=0.1, body_count=1,
+            global_position=(0.0, 0.05, 0.0),
+            transform2=Transform3D(
+                translation=(0.0, 0.05, 0.0), rotation=r_child_world
+            ),
+            local_transform=Transform3D(),
+        ),
+    }
+    snap.joints = {
+        "thumb_mip": FusionJoint(
+            name="thumb_mip", defining_component="right_arm",
+            motion_type="revolute",
+            occurrence_one_path="thumb v1:1", occurrence_one_clean="thumb",
+            occurrence_two_path="palm v1:1", occurrence_two_clean="palm",
+            origin_global_m=(0.0, 0.05, 0.0),
+            origin_source="occ_one_global",
+            axis_vector=axis_world,
+            has_rotation_limits=True,
+            rotation_min=0.0, rotation_max=1.0,
+        ),
+    }
+    model = build_model(snap, _make_logger())
+    j = model.joints["thumb_mip"]
+    for i, expected in enumerate(axis_local):
+        assert abs(j.axis[i] - expected) < 1e-6, (
+            f"mirrored thumb axis[{i}]={j.axis[i]}, expected {expected} "
+            f"(full axis={j.axis}). Double-applying R_arm would skew this."
+        )
+    print(" mirrored_subasm_axis_not_double_rotated: PASS")
+
+
+def test_mirrored_subasm_joint_origin_uses_occurrence_local_geometry():
+    """Nested joints must lift geometryOrOriginOne through the *child
+    occurrence* world pose, not through the defining assembly frame.
+
+    Harper-style failure mode: a right arm mounted with a large rotation
+    (mirror) stores ``geometry.origin`` near the assembly origin while
+    ``geometryOrOriginOne`` is (0,0,0) in the child link's local frame
+    (joint coincides with the component origin). Lifting
+    ``geometry.origin`` via ``R_asm * p + t_asm`` puts the URDF pivot at
+    the assembly origin and produces metre-scale mesh bake offsets - 
+    parts orbit far from the real joint when moved in RViz.
+
+    With the Autodesk-recommended lift (occ1 local -> child world pose),
+    bake stays ~0 and the joint origin sits on the child.
+    """
+    import math
+    from ..core.data_types import (
+        FusionSnapshot, FusionOccurrence, FusionJoint, Transform3D,
+    )
+    from ..core.robot_model import build_model
+
+    # Mount rotation ~ Harper right arm: 180 deg roll + 90 deg yaw
+    roll = math.pi
+    yaw = math.pi / 2
+    cr, sr = math.cos(roll), math.sin(roll)
+    cy, sy = math.cos(yaw), math.sin(yaw)
+    # R = Rz(yaw) * Rx(roll)
+    Rx = (1.0, 0.0, 0.0,
+          0.0, cr, -sr,
+          0.0, sr, cr)
+    Rz = (cy, -sy, 0.0,
+          sy, cy, 0.0,
+          0.0, 0.0, 1.0)
+    # row-major multiply Rz * Rx
+    def mm(a, b):
+        return (
+            a[0]*b[0] + a[1]*b[3] + a[2]*b[6],
+            a[0]*b[1] + a[1]*b[4] + a[2]*b[7],
+            a[0]*b[2] + a[1]*b[5] + a[2]*b[8],
+            a[3]*b[0] + a[4]*b[3] + a[5]*b[6],
+            a[3]*b[1] + a[4]*b[4] + a[5]*b[7],
+            a[3]*b[2] + a[4]*b[5] + a[5]*b[8],
+            a[6]*b[0] + a[7]*b[3] + a[8]*b[6],
+            a[6]*b[1] + a[7]*b[4] + a[8]*b[7],
+            a[6]*b[2] + a[7]*b[5] + a[8]*b[8],
+        )
+    R_arm = mm(Rz, Rx)
+    t_arm = (0.012, 0.021, 0.010)
+
+    # Child sits 0.45 m along the arm's local +X (finger-ish offset).
+    child_local = (0.45, 0.05, 0.02)
+    child_world = (
+        R_arm[0]*child_local[0] + R_arm[1]*child_local[1] + R_arm[2]*child_local[2] + t_arm[0],
+        R_arm[3]*child_local[0] + R_arm[4]*child_local[1] + R_arm[5]*child_local[2] + t_arm[1],
+        R_arm[6]*child_local[0] + R_arm[7]*child_local[1] + R_arm[8]*child_local[2] + t_arm[2],
+    )
+    parent_local = (0.10, 0.0, 0.0)
+    parent_world = (
+        R_arm[0]*parent_local[0] + R_arm[1]*parent_local[1] + R_arm[2]*parent_local[2] + t_arm[0],
+        R_arm[3]*parent_local[0] + R_arm[4]*parent_local[1] + R_arm[5]*parent_local[2] + t_arm[1],
+        R_arm[6]*parent_local[0] + R_arm[7]*parent_local[1] + R_arm[8]*parent_local[2] + t_arm[2],
+    )
+
+    arm = "right_arm v1:1"
+    parent = f"{arm}+proximal v1:1"
+    child = f"{arm}+distal v1:1"
+
+    snap = FusionSnapshot(design_name="harper", design_name_clean="harper")
+    snap.occurrences = {
+        arm: FusionOccurrence(
+            full_path=arm, clean_name="right_arm",
+            path_segments=["right_arm"], depth=0, is_subassembly=True,
+            global_position=t_arm,
+            transform2=Transform3D(translation=t_arm, rotation=R_arm),
+            local_transform=Transform3D(translation=t_arm, rotation=R_arm),
+        ),
+        parent: FusionOccurrence(
+            full_path=parent, clean_name="proximal",
+            path_segments=["right_arm", "proximal"], depth=1,
+            mass_kg=1.0, body_count=1,
+            global_position=parent_world,
+            transform2=Transform3D(translation=parent_world, rotation=R_arm),
+            local_transform=Transform3D(translation=parent_local),
+        ),
+        child: FusionOccurrence(
+            full_path=child, clean_name="distal",
+            path_segments=["right_arm", "distal"], depth=1,
+            mass_kg=0.5, body_count=1,
+            global_position=child_world,
+            transform2=Transform3D(translation=child_world, rotation=R_arm),
+            local_transform=Transform3D(translation=child_local),
+        ),
+    }
+    snap.joints = {
+        "finger_joint": FusionJoint(
+            name="finger_joint",
+            defining_component="right_arm",
+            motion_type="revolute",
+            occurrence_one_path="distal v1:1",
+            occurrence_one_clean="distal",
+            occurrence_two_path="proximal v1:1",
+            occurrence_two_clean="proximal",
+            # Misleading assembly-local origin at the sub-asm origin - 
+            # the old lift path would put the pivot at t_arm.
+            geometry_origin_cm=(0.0, 0.0, 0.0),
+            origin_global_m=(0.0, 0.0, 0.0),
+            origin_source="geometry.origin",
+            # Truth: joint coincides with the child component origin.
+            geometry_or_origin_one_cm=(0.0, 0.0, 0.0),
+            geometry_or_origin_two_cm=(35.0, 5.0, 2.0), # cm, unused when occ1 present
+            axis_vector=(0.0, 0.0, 1.0),
+            has_rotation_limits=True,
+            rotation_min=-1.0,
+            rotation_max=1.0,
+        ),
+    }
+
+    model = build_model(snap, _make_logger())
+    assert "finger_joint" in model.joints
+    joint = model.joints["finger_joint"]
+    distal = model.links["distal"]
+
+    # Joint world pivot must be the child occurrence origin, not t_arm.
+    assert abs(joint.origin_global[0] - child_world[0]) < 1e-6
+    assert abs(joint.origin_global[1] - child_world[1]) < 1e-6
+    assert abs(joint.origin_global[2] - child_world[2]) < 1e-6
+
+    # No metre-scale bake - child origin == joint pivot.
+    assert not distal.needs_mesh_bake, (
+        f"expected no mesh bake when joint is at child origin, got "
+        f"{distal.mesh_bake_offset}"
+    )
+    bake_mag = sum(c * c for c in distal.mesh_bake_offset) ** 0.5
+    assert bake_mag < 1e-6, f"bake magnitude {bake_mag} m should be ~0"
+
+    print(" mirrored_subasm_joint_origin_uses_occurrence_local_geometry: PASS")
+
+
+def test_world_proxied_joint_origin_not_double_lifted_and_bakes():
+    """Assembly-context proxy origins are already world-frame.
+
+    Harper nested arm joints need ``createForAssemblyContext`` so Fusion
+    exposes ``geometryOrOriginOne``. Those points arrive in root cm.
+    Phase 2 must use them as-is (no child-pose lift) and still mesh-bake
+    when the child component origin is far from the hinge.
+    """
+    from ..core.data_types import (
+        FusionSnapshot, FusionOccurrence, FusionJoint, Transform3D,
+    )
+    from ..core.robot_model import build_model
+
+    parent = "left_arm:1+left_wrs_upp_link:1"
+    child = "left_arm:1+left_wrs_low_link:1"
+    # Child component origin far from hinge (Harper-style).
+    child_world = (-0.1068, -0.0616, -0.1992)
+    # True hinge near the visual wrist (world metres).
+    hinge_world = (0.4687, -0.0941, -0.4007)
+    parent_world = (0.4687, -0.0941, -0.4007)
+
+    snap = FusionSnapshot(
+        design_name="harper",
+        design_name_clean="harper",
+        root_component_name="harper",
+        occurrences={
+            "base:1": FusionOccurrence(
+                full_path="base:1",
+                component_name="base",
+                clean_name="base",
+                path_segments=["base"],
+                depth=0,
+                global_position=(0.0, 0.0, 0.0),
+                local_transform=Transform3D(),
+                transform2=Transform3D(),
+                mass_kg=1.0,
+                body_count=1,
+            ),
+            parent: FusionOccurrence(
+                full_path=parent,
+                component_name="left_wrs_upp_link",
+                clean_name="left_wrs_upp_link",
+                path_segments=["left_arm", "left_wrs_upp_link"],
+                depth=1,
+                global_position=parent_world,
+                local_transform=Transform3D(),
+                transform2=Transform3D(),
+                mass_kg=0.4,
+                body_count=1,
+            ),
+            child: FusionOccurrence(
+                full_path=child,
+                component_name="left_wrs_low_link",
+                clean_name="left_wrs_low_link",
+                path_segments=["left_arm", "left_wrs_low_link"],
+                depth=1,
+                global_position=child_world,
+                local_transform=Transform3D(),
+                transform2=Transform3D(),
+                mass_kg=0.014,
+                body_count=1,
+                # CoM far from component origin - geometry near hinge.
+                com_component_local=(
+                    hinge_world[0] - child_world[0],
+                    hinge_world[1] - child_world[1],
+                    hinge_world[2] - child_world[2],
+                ),
+            ),
+        },
+        joints={
+            "mount": FusionJoint(
+                name="mount",
+                joint_source="regular",
+                defining_component="harper",
+                occurrence_one_path=parent,
+                occurrence_two_path="base:1",
+                occurrence_one_clean="left_wrs_upp_link",
+                occurrence_two_clean="base",
+                origin_global_m=parent_world,
+                origin_source="geometryOrOriginOne",
+                motion_type="rigid",
+            ),
+            "left_wrs_fex_joint": FusionJoint(
+                name="left_wrs_fex_joint",
+                joint_source="regular",
+                defining_component="left_arm",
+                occurrence_one_path=child,
+                occurrence_two_path=parent,
+                occurrence_one_clean="left_wrs_low_link",
+                occurrence_two_clean="left_wrs_upp_link",
+                # Stored as world cm by Phase-1 proxy path, converted to m.
+                geometry_or_origin_one_cm=(
+                    hinge_world[0] * 100.0,
+                    hinge_world[1] * 100.0,
+                    hinge_world[2] * 100.0,
+                ),
+                origin_global_m=hinge_world,
+                origin_source="geometryOrOriginOne_world",
+                origin_is_world=True,
+                motion_type="revolute",
+                axis_vector=(0.0, -1.0, 0.0),
+                has_rotation_limits=True,
+                rotation_min=-1.2,
+                rotation_max=1.5,
+            ),
+        },
+        total_joints=2,
+        total_regular_joints=2,
+    )
+    model = build_model(snap, _make_logger())
+    j = model.joints["left_wrs_fex_joint"]
+    child_link = model.links["left_wrs_low_link"]
+
+    # Joint origin relative to parent ~ 0 (hinge ~ parent pose here).
+    assert abs(j.origin_xyz[0]) < 1e-6
+    assert abs(j.origin_xyz[1]) < 1e-6
+    assert abs(j.origin_xyz[2]) < 1e-6
+
+    # Bake must pull the mesh from the distant component origin onto the hinge.
+    assert child_link.needs_mesh_bake, (
+        f"expected mesh bake for offset child origin, got "
+        f"{child_link.mesh_bake_offset}"
+    )
+    bake = child_link.mesh_bake_offset
+    # bake_world = child_world - hinge_world; identity rotation -> same local.
+    expected = (
+        child_world[0] - hinge_world[0],
+        child_world[1] - hinge_world[1],
+        child_world[2] - hinge_world[2],
+    )
+    for i in range(3):
+        assert abs(bake[i] - expected[i]) < 1e-6, (
+            f"bake[{i}]={bake[i]}, expected {expected[i]}"
+        )
+    print(" world_proxied_joint_origin_not_double_lifted_and_bakes: PASS")
+
+
+def test_occ_one_global_prefers_transform2_over_buggy_walk():
+    """When geometry origins are missing, Phase 1 may store a wrong
+    ``occ_one_global`` from the translation-only assemblyContext walk.
+    Phase 2 must use the child occurrence's transform2-backed
+    ``global_position`` instead - otherwise mirrored nested arms get
+    metre-scale bake offsets (Harper: fine at Center, broken on Randomize).
+    """
+    import math
+    from ..core.data_types import (
+        FusionSnapshot, FusionOccurrence, FusionJoint, Transform3D,
+    )
+    from ..core.robot_model import build_model
+
+    roll = math.pi
+    cr, sr = math.cos(roll), math.sin(roll)
+    R = (1.0, 0.0, 0.0,
+         0.0, cr, -sr,
+         0.0, sr, cr)
+    # Child true world pose (transform2)
+    child_world = (-0.03, -0.06, -0.08)
+    # Buggy walk value stored as origin_global_m (Harper-like)
+    buggy_joint = (0.63, -0.06, 0.08)
+    parent_world = (0.05, -0.06, -0.08)
+
+    arm = "right_arm v1:1"
+    parent = f"{arm}+proximal v1:1"
+    child = f"{arm}+distal v1:1"
+
+    snap = FusionSnapshot(design_name="harper", design_name_clean="harper")
+    snap.occurrences = {
+        arm: FusionOccurrence(
+            full_path=arm, clean_name="right_arm",
+            path_segments=["right_arm"], depth=0, is_subassembly=True,
+            global_position=(0.01, 0.02, 0.01),
+            transform2=Transform3D(translation=(0.01, 0.02, 0.01), rotation=R),
+        ),
+        parent: FusionOccurrence(
+            full_path=parent, clean_name="proximal",
+            path_segments=["right_arm", "proximal"], depth=1,
+            mass_kg=1.0, body_count=1,
+            global_position=parent_world,
+            transform2=Transform3D(translation=parent_world, rotation=R),
+        ),
+        child: FusionOccurrence(
+            full_path=child, clean_name="distal",
+            path_segments=["right_arm", "distal"], depth=1,
+            mass_kg=0.5, body_count=1,
+            global_position=child_world,
+            transform2=Transform3D(translation=child_world, rotation=R),
+        ),
+    }
+    snap.joints = {
+        "j": FusionJoint(
+            name="j",
+            defining_component="right_arm",
+            motion_type="revolute",
+            occurrence_one_path="distal v1:1",
+            occurrence_one_clean="distal",
+            occurrence_two_path="proximal v1:1",
+            occurrence_two_clean="proximal",
+            origin_global_m=buggy_joint,
+            origin_source="occ_one_global",
+            axis_vector=(0.0, 0.0, 1.0),
+            has_rotation_limits=True,
+            rotation_min=-1.0,
+            rotation_max=1.0,
+        ),
+    }
+
+    model = build_model(snap, _make_logger())
+    joint = model.joints["j"]
+    distal = model.links["distal"]
+
+    assert abs(joint.origin_global[0] - child_world[0]) < 1e-6
+    assert abs(joint.origin_global[1] - child_world[1]) < 1e-6
+    assert abs(joint.origin_global[2] - child_world[2]) < 1e-6
+    assert not distal.needs_mesh_bake, (
+        f"expected no bake when joint uses child transform2, got "
+        f"{distal.mesh_bake_offset}"
+    )
+    print(" occ_one_global_prefers_transform2_over_buggy_walk: PASS")
 
 
 def test_assembly_links_list_no_clean_name_duplicates():
@@ -2343,6 +2794,10 @@ def run_all():
     test_internal_rigid_group_rigid_joints_are_quietly_dropped()
     test_nested_subasm_link_origin_invariant_under_parent_rotation()
     test_nested_subasm_joint_axis_invariant_under_parent_rotation()
+    test_mirrored_subasm_axis_not_double_rotated()
+    test_mirrored_subasm_joint_origin_uses_occurrence_local_geometry()
+    test_world_proxied_joint_origin_not_double_lifted_and_bakes()
+    test_occ_one_global_prefers_transform2_over_buggy_walk()
     test_passive_joint_propagates_flag()
     test_link_properties_preserved()
     test_rigid_group_merge_two_members()

--- a/tools/check.py
+++ b/tools/check.py
@@ -1,4 +1,4 @@
-﻿"""
+"""
 Check — Validate a Fusion snapshot and report kinematic chain issues.
 
 Builds the RobotModel from snapshot.json, runs validation, and prints
@@ -64,13 +64,20 @@ def _snapshot_from_dict(data: dict) -> FusionSnapshot:
     )
 
     for path, od in data.get('occurrences', {}).items():
-        t_data = od.get('local_transform', {})
-        t_trans = t_data.get('translation', [0, 0, 0])
-        t_rot = t_data.get('rotation', [1, 0, 0, 0, 1, 0, 0, 0, 1])
-        if t_rot and isinstance(t_rot[0], list):
-            t_rot = tuple(v for row in t_rot for v in row)
-        else:
-            t_rot = tuple(t_rot) if t_rot else (1, 0, 0, 0, 1, 0, 0, 0, 1)
+        def _parse_tf(tdata):
+            if not tdata:
+                return Transform3D()
+            t_trans = tdata.get('translation', [0, 0, 0])
+            t_rot = tdata.get('rotation', [1, 0, 0, 0, 1, 0, 0, 0, 1])
+            if t_rot and isinstance(t_rot[0], list):
+                t_rot = tuple(v for row in t_rot for v in row)
+            else:
+                t_rot = tuple(t_rot) if t_rot else (1, 0, 0, 0, 1, 0, 0, 0, 1)
+            return Transform3D(translation=tuple(t_trans), rotation=t_rot)
+
+        local_tf = _parse_tf(od.get('local_transform', {}))
+        t2 = od.get('transform2')
+        transform2 = _parse_tf(t2) if t2 else None
 
         i_com = od.get('inertia_at_com', {})
         i_orig = od.get('inertia_at_origin', {})
@@ -83,7 +90,8 @@ def _snapshot_from_dict(data: dict) -> FusionSnapshot:
             depth=od.get('depth', 0),
             is_subassembly=od.get('is_subassembly', False),
             global_position=tuple(od.get('global_position', [0, 0, 0])),
-            local_transform=Transform3D(translation=tuple(t_trans), rotation=t_rot),
+            local_transform=local_tf,
+            transform2=transform2,
             assembly_context_depth=od.get('assembly_context_depth', 0),
             mass_kg=od.get('mass_kg', 0),
             body_count=od.get('body_count', 0),
@@ -101,6 +109,10 @@ def _snapshot_from_dict(data: dict) -> FusionSnapshot:
         snap.occurrences[path] = occ
 
     for jname, jd in data.get('joints', {}).items():
+        def _opt_vec(key):
+            v = jd.get(key)
+            return tuple(v) if v else None
+
         joint = FusionJoint(
             name=jd.get('name', jname),
             joint_source=jd.get('joint_source', ''),
@@ -110,6 +122,12 @@ def _snapshot_from_dict(data: dict) -> FusionSnapshot:
             occurrence_one_clean=jd.get('occurrence_one_clean', ''),
             occurrence_two_path=jd.get('occurrence_two_path', ''),
             occurrence_two_clean=jd.get('occurrence_two_clean', ''),
+            geometry_origin_cm=_opt_vec('geometry_origin_cm'),
+            geometry_or_origin_one_cm=_opt_vec('geometry_or_origin_one_cm'),
+            geometry_or_origin_two_cm=_opt_vec('geometry_or_origin_two_cm'),
+            occ_one_transform_cm=_opt_vec('occ_one_transform_cm'),
+            occ_one_transform2_cm=_opt_vec('occ_one_transform2_cm'),
+            occ_one_global_cm=_opt_vec('occ_one_global_cm'),
             origin_global_m=tuple(jd.get('origin_global_m', [0, 0, 0])),
             origin_source=jd.get('origin_source', ''),
             axis_vector=tuple(jd.get('axis_vector', [0, 0, 1])),


### PR DESCRIPTION
Regular joints defined inside nested subassemblies often came back with null `geometry` / `geometryOrOriginOne` when read from the root design. Without a real hinge point, the exporter fell back to the child component pose, so URDF link frames ended up in the wrong place like links orbited the component origin instead of the actual joint.

To fix this, nested joints are now proxied into an assembly occurrence with `createForAssemblyContext`, which is what Fusion needs to expose the real hinge origin in root/world coordinates. Those origins are marked as world-proxied so it does not lift them again through the child pose (that was double-applying the subassembly transform). For joints that still report local origins, they continue to be lifted through the child/parent world pose as before.

Also cleaned up axis handling: revolute and prismatic axes are remapped as `R_child^T * axis_world` only, without the old defining-assembly pre-multiply that could skew nested or mirrored mounts. Origin fallbacks now prefer occurrence `transform2` over the assemblyContext walk. Docs and tests cover the nested-joint path and the remaining edge cases where a `!frame_*` may still be needed.

