### PR TITLE
Harden frame and mesh export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 
 # Runtime export artifacts — regenerated on every run.
 debug/
+/test_exports/
 
 # Personal exporter config — copy from xacro_export.template.toml
 # and edit; the personal file stays local so each contributor can
@@ -14,5 +15,10 @@ xacro_export.toml
 !.vscode/settings.json
 
 # Test scratch
-.test_tmp/
-.test_tmp_ci/
+.test_tmp*/
+.codex_tmp/
+.codex_verify_tmp*/
+fusion_root_bodies_*/
+.pytest_cache/
+.coverage
+htmlcov/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to **fusion2URDF** are documented here. The format
 follows [Keep a Changelog](https://keepachangelog.com/), and the
 project adheres to [Semantic Versioning](https://semver.org/).
 
+## [3.1.0] - 2026-08-14
+
+### Added
+
+- Post-export, orientation-only frame rebasing. The default ROS convention
+  keeps the Fusion design-world root `X` forward and `Z` up, and expresses
+  revolute and continuous joint axes as child-local `+Z`.
+- Editable `config/frame_overrides.csv` rules (`auto`, `keep`, and
+  `world_rpy`) plus an offline `python -m fusion2URDF.tools.reframe` command.
+- A canonical `debug/frame_model.json` cache, allowing frame-dependent URDF,
+  xacro, YAML, and documentation files to be regenerated without reopening
+  Fusion or exporting meshes again.
+- Regression coverage for frame invariance, cache round-trips, nested rigid
+  group anchors, and subassembly-container joint endpoints.
+
+### Fixed
+
+- Merged rigid-group OBJ meshes now use the anchor pose relative to the actual
+  export lowest common ancestor. Nested anchors no longer displace a link's
+  mesh far away from its physical placement.
+- Joint endpoints that target a subassembly container now resolve to that
+  subassembly's deterministic internal root link instead of producing an
+  invalid or misplaced connection.
+- Frame-only links remain valid links without fabricated visual, collision,
+  mass, or inertia blocks.
+- Jointless single-body designs now export a deterministic root link, and
+  part-number assembly names produce valid XML/xacro macro names.
+
+### Changed
+
+- Mesh, collision, center-of-mass, inertia, joint-origin, and joint-axis data
+  are compensated together when a frame is rebased, preserving the physical
+  mechanism and visible geometry.
+- Snapshot JSON loading is shared by the validation and reframe tools.
+- Generated exports, debug data, Python caches, and local test scratch remain
+  ignored; the curated source designs and examples stay tracked.
+
 ## [3.0.0] — 2026-05-04
 
 Initial public release.

--- a/DESIGN_GUIDE.md
+++ b/DESIGN_GUIDE.md
@@ -213,8 +213,9 @@ the URDF link and joint frame are centered on the wheel axis.
 
 ![Wheel frame marker in rigid group](docs/images/frame-workflow/wheel-frame-marker-in-rigid-group.png)
 
-Check the axis before exporting. For the usual ROS convention, the wheel
-can rotate around local `Y` while local `Z` points up.
+Check the physical axis before exporting. With the default ROS frame
+convention, the exporter rebases each revolute child link so that this same
+physical axis becomes local `+Z`; the wheel mesh itself does not move.
 
 ![Wheel frame axis alignment](docs/images/frame-workflow/wheel-frame-axis-alignment.png)
 
@@ -572,7 +573,21 @@ Use this loop while modelling:
 9. Do a minimal-mode export to surface warnings cheaply.
 10. Fix warnings while the model is still easy to change.
 11. Run a full export with `fusion2URDF`.
-12. Inspect the generated URDF in VS Code, RViz, Gazebo, or Isaac Sim.
+12. Inspect `config/frame_overrides.csv`; leave `rule=auto` for the default
+    root `X`-forward/`Z`-up and revolute-axis `+Z` convention.
+13. Inspect the generated URDF in VS Code, RViz, Gazebo, or Isaac Sim.
+
+If a non-root link frame is still awkward, set its CSV rule to `world_rpy`,
+enter the desired absolute design-world orientation in `post_*_deg`, and run:
+
+```powershell
+python tools/reframe.py <robot>_description
+```
+
+This is an offline coordinate-frame change: cached geometry is compensated,
+so the mesh and physical mechanism do not move. A position/origin change is a
+different operation; put a `!frame_*` helper at the intended position in
+Fusion and export again.
 
 ## Common Problems
 
@@ -582,7 +597,8 @@ Use this loop while modelling:
 | Robot root is surprising | Joint direction is flipped | Check `occurrenceOne`/`occurrenceTwo` in Fusion |
 | Visual part missing | It was tagged `!collision_*` | Rename it unless it is meant as collision |
 | Rigid group exports oddly | Internal joint inside the group | Move the joint between links |
-| Link frame is wrong | Component origin is not the desired URDF frame | Add a `!frame_*` helper to the rigid group |
+| Link orientation is awkward | Exported axes are inconvenient | Edit `config/frame_overrides.csv` and run the offline reframe tool |
+| Link origin or joint position is wrong | Component origin is not the desired URDF frame | Add a `!frame_*` helper to the rigid group and export again |
 | Collision is too large | Primitive fit is too rough | Add simplified `!collision_*` geometry |
 | Simulation is slow | Too much exact mesh collision | Use primitives except where `!acc_*` is needed |
 | Closed loop warning | Link has multiple parents | Tag the intended loop-closing joint with `!closing_*` |

--- a/DESIGN_RULES.md
+++ b/DESIGN_RULES.md
@@ -412,6 +412,39 @@ Bake offsets appear in:
 - `<collision><origin>`
 - `bake_offset_m` in `robot_data.yaml`
 
+### 4.3 Post-Export Orientation Frames
+
+The default `[frames].convention = "ros"` applies an orientation-only frame
+layer after the canonical Fusion model has been built:
+
+- the URDF root follows the Fusion design world, with `X` forward and `Z` up
+- every revolute or continuous joint rotates about its child link's local `+Z`
+- visual meshes, collision geometry, inertial data, and physical joint motion
+  keep the same world poses
+
+Verbose exports write `config/frame_overrides.csv`. The `original_*` columns
+describe the extracted frames. Set a non-root link to `rule=world_rpy`, edit
+its `post_*_deg` columns, and reapply the frame layer without Fusion or mesh
+export:
+
+```powershell
+python tools/reframe.py <robot>_description
+```
+
+The offline command reads the canonical `debug/frame_model.json` cache. It
+rewrites only frame-dependent URDF, xacro, YAML, config, and documentation
+files. For a package exported before this cache existed, bootstrap it once
+from a matching snapshot:
+
+```powershell
+python tools/reframe.py <robot>_description --snapshot debug/snapshot.json
+```
+
+CSV overrides intentionally change orientation only. Moving a revolute frame
+away from its physical axis would change the motion unless an extra virtual
+frame were introduced. Use a Fusion `!frame_*` helper and export again when
+the frame position or joint origin must change.
+
 ## 5. Special Link Types
 
 ### 5.1 Empty Links and Reference Frames
@@ -472,10 +505,13 @@ Main outputs:
 | `urdf/assemblies/*.urdf.xacro` | Per-assembly macros |
 | `meshes/<assembly>/` | Visual and collision meshes |
 | `config/ros2_controllers.yaml` | Generated ros2_control controller configuration when enabled |
+| `config/frame_overrides.csv` | Editable post-export link orientation rules in verbose exports |
+| `config/FRAME_OVERRIDES.md` | Short guide for the frame override CSV |
 | `robot_data.yaml` | Data URDF cannot represent |
 | `docs/transforms.md` | Homogeneous transform chains |
 | `images/robot.png` | Fusion viewport screenshot |
 | `debug/snapshot.json` | Raw extraction snapshot |
+| `debug/frame_model.json` | Canonical model cache for offline frame regeneration |
 | `debug/export_log.md` | Export log |
 | `debug/validation.md` | Validation summary |
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,29 @@ The whole thing is built on one idea: the exporter shall adapt to **your design 
 
 If your design style breaks it, please file an issue describing how. I don't think it will (jk, it probably will). And of course, all of the above is configurable through `xacro_export.toml`.
 
+## What's new in 3.1
+
+Version 3.1 adds a post-export frame layer. By default, the root follows the
+Fusion design world with `X` forward and `Z` up, while each revolute or
+continuous joint rotates about its child link's local `+Z`. Visual meshes,
+collision geometry, inertial data, joint origins, and physical motion are
+compensated together, so changing the coordinate frames does not move the
+robot.
+
+Verbose exports include `config/frame_overrides.csv` and a canonical
+`debug/frame_model.json` cache. Edit a frame rule and regenerate the
+frame-dependent files without reopening Fusion or exporting meshes again:
+
+```powershell
+# From the fusion2URDF repository root:
+python tools/reframe.py <path-to-robot_description>
+```
+
+This release also fixes nested rigid-group mesh anchoring and resolves Fusion
+joints aimed at a subassembly container to that subassembly's real root link.
+Jointless parts export cleanly as single-link packages, and assembly names
+that begin with part numbers now generate XML-safe xacro macros.
+
 ![Exported Panther frames preview](docs/images/frame-workflow/exported-panther-frames-preview.png)
 
 > Here is the Husarion Panther exported with fusion2URDF, viewed in RViz. Every link, joint, mesh, frame, and `ros2_control` block was generated automatically from the Fusion design.
@@ -97,7 +120,7 @@ The exporter runs out of the box. To pin local defaults, copy the template:
 cp xacro_export.template.toml xacro_export.toml
 ```
 
-`xacro_export.toml` is gitignored so each contributor keeps their own. The three settings most people end up touching:
+`xacro_export.toml` is gitignored so each contributor keeps their own. Common settings:
 
 ```toml
 [output]
@@ -117,6 +140,12 @@ visual_format = "dae"
 # "convex_hull"  generates a convex STL from the visual mesh vertices.
 # "visual_reuse" uses the visual mesh as collision (heavy but exact).
 collision_method = "primitive"
+
+[frames]
+# "ros" gives the root X-forward/Z-up and movable child axes on local +Z.
+# "fusion" keeps the orientations extracted from Fusion unless CSV-overridden.
+convention = "ros"
+overrides_file = "frame_overrides.csv"
 ```
 
 The full list (per-feature toggles, ros2_control hardware plugin, zip output, mesh refinement) is in [`xacro_export.template.toml`](xacro_export.template.toml) with comments next to every key.
@@ -160,6 +189,7 @@ No URDF edits, no missing meshes, no broken joint frames. (If you find one, file
 - **Six-strategy collision pipeline**: explicit `!collision_*` geometry, per-link `!acc_*` / `!cxh_*` / `!pri_*` overrides, auto-fitted primitive (box / cylinder / sphere) from bounding box, generated convex hulls, or visual-mesh fallback. Yes, you can mix all of them in one robot.
 - **Closed-loop joint sidecar.** URDF can't model cycles, so loop-closing joints (tag with `!closing_*`) are excluded from the URDF tree and emitted to `robot_data.yaml` for downstream URDF-to-USD pipelines.
 - **Frame helpers** (`!frame_*`) let you set link origins and joint axes without remodelling. Geometry is ignored, the frame is exported.
+- **Offline frame control** rebases link orientations without moving geometry or changing joint motion. Use the generated CSV for `auto`, `keep`, or absolute non-root `world_rpy` rules, then replay it from the cached canonical model.
 - **Body-level visual-only marker.** Prefix any body name with `!` to keep it in the visual mesh but exclude it from generated collision (primitives don't wrap it, convex hulls don't expand to it).
 - **Placeholder modules** (`!dummy_*`) are RViz-visible but excluded from `robot_data.yaml`, so you can ship a complete visual model with sensors, tools, or payloads to be swapped in later.
 - **Symbolic transforms** in KaTeX (`docs/transforms.md`) plus a JSON snapshot of the entire extraction for offline analysis without Fusion.
@@ -195,24 +225,32 @@ Both packages are self-contained and launch in RViz with no edits.
 <summary>Click to see the full output tree</summary>
 
 ```text
-<robot>_description/
-├── urdf/
-│   ├── <robot>.urdf.xacro           Entry point
-│   ├── assemblies/<asm>.urdf.xacro  Per-assembly xacro macros
-│   └── <robot>.urdf                 Flat URDF for validation
-├── meshes/<assembly>/
-│   ├── <link>.dae                   Visual mesh (DAE or OBJ+MTL)
-│   └── <link>_collision.stl         Collision mesh where generated
-├── launch/display.launch.py         RViz2 visualization
-├── config/joint_state.yaml
-├── config/ros2_controllers.yaml     ros2_control config
-├── rviz/display.rviz
-├── robot_data.yaml                  Supplementary data beyond URDF
-├── docs/transforms.md               Joint transforms (KaTeX)
-├── images/robot.png                 Fusion viewport screenshot
-├── README.md                        Auto-generated package README
-├── package.xml
-└── CMakeLists.txt
+<output_dir>/
+├── <robot>_description/
+│   ├── urdf/
+│   │   ├── <robot>.urdf.xacro           Entry point
+│   │   ├── assemblies/<asm>.urdf.xacro  Per-assembly xacro macros
+│   │   └── <robot>.urdf                 Flat URDF for validation
+│   ├── meshes/<assembly>/
+│   │   ├── <link>.dae                   Visual mesh (DAE or OBJ+MTL)
+│   │   └── <link>_collision.stl         Collision mesh where generated
+│   ├── launch/display.launch.py         RViz2 visualization
+│   ├── config/joint_state.yaml
+│   ├── config/ros2_controllers.yaml     ros2_control config
+│   ├── config/frame_overrides.csv       Editable frame orientations
+│   ├── config/FRAME_OVERRIDES.md        CSV rule reference
+│   ├── rviz/display.rviz
+│   ├── robot_data.yaml                  Supplementary data beyond URDF
+│   ├── docs/transforms.md               Joint transforms (KaTeX)
+│   ├── images/robot.png                 Fusion viewport screenshot
+│   ├── README.md                        Auto-generated package README
+│   ├── package.xml
+│   └── CMakeLists.txt
+└── debug/
+    ├── snapshot.json                    Raw Fusion extraction cache
+    ├── frame_model.json                 Canonical offline reframe cache
+    ├── validation.md
+    └── export_log.md
 ```
 
 </details>
@@ -226,6 +264,7 @@ Both packages are self-contained and launch in RViz with no edits.
 | [Design Rules](DESIGN_RULES.md) | Required conventions and reserved prefixes |
 | [ROS 2 Usage](docs/ROS2.md) | Build, launch, RViz2, validation, topics |
 | [Customizing](docs/CUSTOMIZING.md) | Collision options, mesh settings, prefixes |
+| [Testing](docs/TESTING.md) | Local CI-equivalent checks, suites, examples, and offline tools |
 | [Limitations](docs/LIMITATIONS.md) | Known gaps and tradeoffs (read this before you file a bug) |
 
 

--- a/core/data_types.py
+++ b/core/data_types.py
@@ -19,7 +19,7 @@ from typing import Dict, List, Optional, Tuple, Any
 # Version
 # ──────────────────────────────────────────────
 
-EXPORTER_VERSION = "3.0.0"
+EXPORTER_VERSION = "3.1.0"
 DESIGN_ROOT_OCCURRENCE_PATH = "__design_root__"
 
 
@@ -311,11 +311,19 @@ class LinkNode:
     
     # Position
     global_position: Vec3 = (0.0, 0.0, 0.0)    # meters, world frame
+    # Original link-local -> Fusion design-world rotation.  Kept on the
+    # Phase-2 model so the pure-Python frame postprocessor can recover the
+    # author's X-forward/Z-up design frame without calling the Fusion API.
+    source_world_rotation: Optional[Tuple[float, ...]] = None
     
     # Physical properties
     mass_kg: float = 0.0
     com_link_local: Vec3 = (0.0, 0.0, 0.0)     # CoM relative to link origin
     inertia_at_com: InertiaTensor = field(default_factory=InertiaTensor)
+    # Optional fully resolved CoM origin in the exported link frame.  The
+    # frame postprocessor sets this after composing component CoM + joint
+    # bake offset; None retains the legacy composition in the generator.
+    inertial_origin_xyz: Optional[Vec3] = None
     
     # Material & appearance
     material_name: str = ""
@@ -363,6 +371,16 @@ class LinkNode:
     # Mesh vertices need baking by this offset to avoid wobble during rotation
     mesh_bake_offset: Vec3 = (0.0, 0.0, 0.0)
     needs_mesh_bake: bool = False
+    # Rotation from the exported link frame to the unchanged mesh frame.
+    # Normally identity.  Frame rebasing changes this origin instead of
+    # rewriting mesh vertices, which keeps DAE/OBJ/STL files reusable.
+    mesh_origin_rpy: RPY = (0.0, 0.0, 0.0)
+
+    # Traceability for the post-export frame layer.  ``frame_rebase_rpy`` is
+    # the pose of the post frame in the original link frame (orientation
+    # only in v1); ``frame_rule`` records auto/keep/world_rpy.
+    frame_rebase_rpy: RPY = (0.0, 0.0, 0.0)
+    frame_rule: str = "keep"
     
     # Empty link (reference frame — no bodies, no visual/collision)
     body_count: int = 0
@@ -520,6 +538,7 @@ class CollisionInfo:
     mesh_path: str = ""             # STL/mesh file once resolved or generated
     primitive: Optional[CollisionPrimitive] = None  # For auto-generated primitives
     origin_xyz: Optional[Vec3] = None  # Override origin (for rigid group collision offset)
+    origin_rpy: RPY = (0.0, 0.0, 0.0)  # Mesh pose after optional frame rebasing
     
     @property
     def uses_primitive(self) -> bool:
@@ -602,6 +621,13 @@ class ExportConfig:
     # URDF options
     use_xacro: bool = False         # Phase 3.1: plain URDF. Future: xacro
     robot_prefix: str = ""          # For multi-robot (empty = no prefix)
+
+    # Post-export frame convention.  ``ros`` aligns the root with Fusion's
+    # design world (X forward, Z up) and makes every revolute/continuous
+    # joint axis local +Z without changing mesh vertices.  ``fusion`` keeps
+    # extracted link frames unless a CSV row explicitly overrides one.
+    frame_convention: str = "ros"
+    frame_overrides_filename: str = "frame_overrides.csv"
 
     # Optional output toggles — controllable via xacro_export.toml.
     # ``verbosity`` is a preset that sets the include_* fields below,

--- a/core/frame_rebaser.py
+++ b/core/frame_rebaser.py
@@ -1,0 +1,728 @@
+"""Post-export link-frame rebasing without mesh modification.
+
+The Fusion extractor produces a physically correct canonical ``RobotModel``
+whose mesh files live in the original component/link coordinate systems.  This
+module changes only the coordinate frames used by URDF/Xacro:
+
+* the root frame can be aligned with Fusion design world (X forward, Z up),
+* revolute/continuous child frames can use local +Z as their joint axis, and
+* a per-package CSV can request an absolute world RPY for any link.
+
+For every link, ``C`` is the orientation of the post frame expressed in the
+original link frame.  Geometry is compensated with ``C^-1`` and joint zero
+poses are changed with ``C_parent^-1 * T_parent_child * C_child``.  Therefore
+the visible/collision geometry and kinematics are unchanged for all joint
+angles; only the names/axes of the coordinate frames change.
+
+Translations are intentionally not part of the v1 override format.  A
+translation perpendicular to a revolute axis does not commute with rotation
+and would require an additional virtual joint frame to preserve motion.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import os
+from dataclasses import asdict, fields
+from typing import Dict, Iterable, Optional, Tuple
+
+from .data_types import (
+    AssemblyInfo,
+    CollisionInfo,
+    CollisionPrimitive,
+    ExportConfig,
+    InertiaTensor,
+    JointLimits,
+    JointNode,
+    LinkNode,
+    RobotModel,
+    RPY,
+    Vec3,
+)
+
+
+Matrix3 = Tuple[float, ...]
+
+IDENTITY_3: Matrix3 = (
+    1.0, 0.0, 0.0,
+    0.0, 1.0, 0.0,
+    0.0, 0.0, 1.0,
+)
+
+FRAME_CACHE_VERSION = 1
+FRAME_CACHE_FILENAME = "frame_model.json"
+FRAME_GUIDE_FILENAME = "FRAME_OVERRIDES.md"
+
+CSV_COLUMNS = (
+    "link",
+    "parent_joint",
+    "joint_type",
+    "rule",
+    "original_roll_deg",
+    "original_pitch_deg",
+    "original_yaw_deg",
+    "post_roll_deg",
+    "post_pitch_deg",
+    "post_yaw_deg",
+    "role",
+)
+
+
+def configure_frames(
+    model: RobotModel,
+    config: ExportConfig,
+    package_dir: str,
+    log=None,
+    emit_artifacts: bool = True,
+) -> Dict[str, dict]:
+    """Load/update the package CSV and apply its frame plan in-place.
+
+    The caller must pass the canonical collision-resolved model.  In the main
+    export pipeline this runs after collision STL generation and immediately
+    before URDF/Xacro generation.
+    """
+    config_dir = os.path.join(package_dir, "config")
+    filename = getattr(config, "frame_overrides_filename", "") or "frame_overrides.csv"
+    csv_path = os.path.join(config_dir, os.path.basename(filename))
+    existing = load_frame_overrides(csv_path, log=log)
+    convention = (getattr(config, "frame_convention", "ros") or "ros").strip().lower()
+
+    plan = plan_frame_rebases(
+        model,
+        overrides=existing,
+        convention=convention,
+        log=log,
+    )
+    if emit_artifacts:
+        os.makedirs(config_dir, exist_ok=True)
+        write_frame_overrides(csv_path, plan)
+        write_frame_guide(os.path.join(config_dir, FRAME_GUIDE_FILENAME))
+    apply_frame_rebases(model, plan, log=log)
+
+    changed = sum(1 for item in plan.values() if not _matrix_close(item["rebase"], IDENTITY_3))
+    _info(log, f"  Frame convention: {convention}")
+    if emit_artifacts:
+        _info(log, f"  Frame overrides:  config/{os.path.basename(csv_path)}")
+    else:
+        _info(log, "  Frame overrides:  not emitted (minimal package)")
+    _info(log, f"  Rebased links:    {changed}/{len(plan)}")
+    return plan
+
+
+def plan_frame_rebases(
+    model: RobotModel,
+    overrides: Optional[Dict[str, dict]] = None,
+    convention: str = "ros",
+    log=None,
+) -> Dict[str, dict]:
+    """Return a simultaneous orientation-only rebase plan for every link."""
+    overrides = overrides or {}
+    convention = (convention or "ros").strip().lower()
+    if convention not in ("ros", "fusion"):
+        _warn(log, f"Unknown frame convention '{convention}'; using 'ros'")
+        convention = "ros"
+
+    original_world = _original_world_rotations(model)
+    parent_joint = {joint.child_link: joint for joint in model.joints.values()}
+    plan: Dict[str, dict] = {}
+
+    for link_name, link in model.links.items():
+        old_world = original_world.get(link_name, IDENTITY_3)
+        joint = parent_joint.get(link_name)
+        role = _automatic_role(model, link_name, joint, convention)
+        default_rule = "auto" if role != "unchanged" else "keep"
+        source_row = overrides.get(link_name, {})
+        rule = str(source_row.get("rule", default_rule) or default_rule).strip().lower()
+        if rule not in ("auto", "keep", "world_rpy"):
+            _warn(log, f"Frame '{link_name}': unknown rule '{rule}', using '{default_rule}'")
+            rule = default_rule
+
+        if rule == "keep":
+            desired_world = old_world
+        elif rule == "world_rpy":
+            requested = _post_rpy_degrees(source_row, link_name, log)
+            if requested is None:
+                rule = default_rule
+                desired_world = _automatic_world_rotation(
+                    model, link_name, joint, role, old_world, log
+                )
+            elif link_name == model.root_link:
+                # A URDF root has no parent joint: its frame *is* the URDF
+                # world and therefore cannot carry an arbitrary world RPY
+                # without adding a wrapper link.  Keep the invariant promised
+                # by this layer (geometry unchanged) and use the convention's
+                # automatic root instead.
+                _warn(
+                    log,
+                    f"Frame '{link_name}': world_rpy is not valid for a URDF "
+                    f"root; using '{default_rule}'",
+                )
+                rule = default_rule
+                desired_world = _automatic_world_rotation(
+                    model, link_name, joint, role, old_world, log
+                )
+            else:
+                desired_world = rpy_to_matrix(tuple(math.radians(v) for v in requested))
+        else:
+            desired_world = _automatic_world_rotation(
+                model, link_name, joint, role, old_world, log
+            )
+
+        # C = R_world_old^T * R_world_new: new basis expressed in old axes.
+        rebase = mat3_mul(mat3_transpose(old_world), desired_world)
+        plan[link_name] = {
+            "link": link_name,
+            "parent_joint": joint.name if joint else "",
+            "joint_type": joint.joint_type if joint else "root",
+            "rule": rule,
+            "role": role,
+            "original_world": old_world,
+            "desired_world": desired_world,
+            "rebase": rebase,
+        }
+
+    return plan
+
+
+def apply_frame_rebases(model: RobotModel, plan: Dict[str, dict], log=None) -> None:
+    """Apply a previously computed frame plan to ``model`` in-place."""
+    if getattr(model, "_frames_applied", False):
+        raise ValueError("Frame rebases have already been applied to this RobotModel")
+
+    rebases: Dict[str, Matrix3] = {
+        name: tuple(item.get("rebase", IDENTITY_3))
+        for name, item in plan.items()
+    }
+
+    # Link payloads are transformed first.  All reads below are from the
+    # canonical model and each link is independent, so ordering is irrelevant.
+    for link_name, link in model.links.items():
+        c = rebases.get(link_name, IDENTITY_3)
+        old_to_new = mat3_transpose(c)  # C^-1 for an orthonormal rotation
+        old_bake = (
+            tuple(link.mesh_bake_offset)
+            if getattr(link, "needs_mesh_bake", False)
+            else (0.0, 0.0, 0.0)
+        )
+
+        old_mesh_rotation = rpy_to_matrix(
+            tuple(getattr(link, "mesh_origin_rpy", (0.0, 0.0, 0.0)))
+        )
+        new_mesh_rotation = mat3_mul(old_to_new, old_mesh_rotation)
+        new_bake = mat3_vec(old_to_new, old_bake)
+
+        # Resolve CoM in the old link frame before rebasing.  Canonical models
+        # store component-local CoM plus the movable-joint bake offset.
+        if getattr(link, "inertial_origin_xyz", None) is not None:
+            old_com = tuple(link.inertial_origin_xyz)
+        else:
+            old_com = vec_add(tuple(link.com_link_local), old_bake)
+        new_com = mat3_vec(old_to_new, old_com)
+
+        link.mesh_bake_offset = _clean_vec(new_bake)
+        link.mesh_origin_rpy = _clean_vec(matrix_to_rpy(new_mesh_rotation))
+        link.inertial_origin_xyz = _clean_vec(new_com)
+        # robot_data.yaml historically exposes com_link_local.  Once a post
+        # frame exists, report the actual exported-link CoM there as well.
+        link.com_link_local = _clean_vec(new_com)
+        link.inertia_at_com = rotate_inertia(link.inertia_at_com, old_to_new)
+        link.needs_mesh_bake = (
+            getattr(link, "needs_mesh_bake", False)
+            or not _matrix_close(c, IDENTITY_3)
+            or not _vec_close(new_bake, (0.0, 0.0, 0.0))
+        )
+        link.frame_rebase_rpy = _clean_vec(matrix_to_rpy(c))
+        link.frame_rule = plan.get(link_name, {}).get("rule", "keep")
+
+        collision = getattr(link, "collision", None)
+        if collision is not None:
+            if collision.origin_xyz is not None:
+                old_collision_origin = tuple(collision.origin_xyz)
+            else:
+                old_collision_origin = old_bake
+                if link.rigid_group_collision_offset:
+                    old_collision_origin = vec_add(
+                        old_collision_origin,
+                        tuple(link.rigid_group_collision_offset),
+                    )
+            old_collision_rotation = rpy_to_matrix(
+                tuple(getattr(collision, "origin_rpy", (0.0, 0.0, 0.0)))
+            )
+            collision.origin_xyz = _clean_vec(
+                mat3_vec(old_to_new, old_collision_origin)
+            )
+            collision.origin_rpy = _clean_vec(
+                matrix_to_rpy(mat3_mul(old_to_new, old_collision_rotation))
+            )
+
+    # Joint zero-pose transform: T' = C_parent^-1 * T * C_child.
+    for joint in _all_joints(model):
+        cp = rebases.get(joint.parent_link, IDENTITY_3)
+        cc = rebases.get(joint.child_link, IDENTITY_3)
+        cp_inv = mat3_transpose(cp)
+        old_rotation = rpy_to_matrix(tuple(joint.origin_rpy))
+        new_rotation = mat3_mul(mat3_mul(cp_inv, old_rotation), cc)
+        joint.origin_xyz = _clean_vec(mat3_vec(cp_inv, tuple(joint.origin_xyz)))
+        joint.origin_rpy = _clean_vec(matrix_to_rpy(new_rotation))
+        if joint.joint_type in ("revolute", "continuous", "prismatic"):
+            axis = normalize(mat3_vec(mat3_transpose(cc), tuple(joint.axis)))
+            joint.axis = _clean_vec(axis)
+
+    model._frames_applied = True
+
+    for joint in model.joints.values():
+        if joint.joint_type in ("revolute", "continuous"):
+            if not _vec_close(joint.axis, (0.0, 0.0, 1.0), tol=1e-7):
+                _warn(
+                    log,
+                    f"Joint '{joint.name}' axis remains {joint.axis}; "
+                    f"set child '{joint.child_link}' to rule=auto to use local +Z",
+                )
+
+
+def load_frame_overrides(path: str, log=None) -> Dict[str, dict]:
+    """Read an existing override CSV keyed by link name."""
+    if not os.path.isfile(path):
+        return {}
+    rows: Dict[str, dict] = {}
+    try:
+        with open(path, "r", encoding="utf-8-sig", newline="") as handle:
+            for row in csv.DictReader(handle):
+                name = str(row.get("link", "") or "").strip()
+                if not name or name.startswith("#"):
+                    continue
+                rows[name] = dict(row)
+    except Exception as exc:
+        _warn(log, f"Could not read frame overrides '{path}': {exc}")
+        return {}
+    return rows
+
+
+def write_frame_overrides(path: str, plan: Dict[str, dict]) -> str:
+    """Write a deterministic reference/edit CSV from a frame plan."""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=CSV_COLUMNS, lineterminator="\n")
+        writer.writeheader()
+        for name in sorted(plan):
+            item = plan[name]
+            original = tuple(math.degrees(v) for v in matrix_to_rpy(item["original_world"]))
+            post = tuple(math.degrees(v) for v in matrix_to_rpy(item["desired_world"]))
+            writer.writerow({
+                "link": name,
+                "parent_joint": item.get("parent_joint", ""),
+                "joint_type": item.get("joint_type", ""),
+                "rule": item.get("rule", "keep"),
+                "original_roll_deg": _fmt_deg(original[0]),
+                "original_pitch_deg": _fmt_deg(original[1]),
+                "original_yaw_deg": _fmt_deg(original[2]),
+                "post_roll_deg": _fmt_deg(post[0]),
+                "post_pitch_deg": _fmt_deg(post[1]),
+                "post_yaw_deg": _fmt_deg(post[2]),
+                "role": item.get("role", "unchanged"),
+            })
+    return path
+
+
+def write_frame_guide(path: str) -> str:
+    """Write the short user guide beside ``frame_overrides.csv``."""
+    text = """# Frame overrides
+
+The exporter changes coordinate frames without changing mesh vertices.
+
+- `rule=auto`: root uses Fusion design world (X forward, Z up); a
+  revolute/continuous child uses local +Z as its rotation axis.
+- `rule=keep`: keep the original extracted link orientation.
+- `rule=world_rpy`: for a non-root link, use `post_roll_deg`, `post_pitch_deg`, and
+  `post_yaw_deg` as the link frame's absolute zero-pose orientation in the
+  Fusion design-world frame.
+
+The URDF root frame is the URDF world and is therefore always handled by
+`auto`/`keep`; an arbitrary root RPY would need an extra wrapper link.
+
+The `original_*` columns are regenerated reference values. Edit only `rule`
+and the `post_*` columns. Translations are intentionally unsupported because
+an arbitrary translated revolute frame would change the physical rotation.
+
+After editing, regenerate only URDF/Xacro/YAML/docs (no Fusion mesh export):
+
+```powershell
+# From the fusion2URDF repository root:
+python tools/reframe.py <path-to-description-package>
+```
+
+From the directory containing the checkout, the equivalent module command is
+`python -m fusion2URDF.tools.reframe <path-to-description-package>`.
+"""
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(text)
+    return path
+
+
+def save_frame_cache(
+    model: RobotModel,
+    config: ExportConfig,
+    path: str,
+) -> str:
+    """Serialize a canonical, collision-resolved model for offline reframing."""
+    payload = {
+        "cache_version": FRAME_CACHE_VERSION,
+        "model": asdict(model),
+        "config": asdict(config),
+    }
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    return path
+
+
+def load_frame_cache(path: str) -> Tuple[RobotModel, ExportConfig]:
+    """Load a model/config pair written by :func:`save_frame_cache`."""
+    with open(path, "r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+    version = payload.get("cache_version")
+    if version != FRAME_CACHE_VERSION:
+        raise ValueError(
+            f"Unsupported frame cache version {version!r}; expected {FRAME_CACHE_VERSION}"
+        )
+    return _model_from_dict(payload.get("model", {})), _config_from_dict(
+        payload.get("config", {})
+    )
+
+
+def rpy_to_matrix(rpy: RPY) -> Matrix3:
+    """URDF RPY (Rz(yaw) * Ry(pitch) * Rx(roll)) to row-major matrix."""
+    roll, pitch, yaw = rpy
+    cr, sr = math.cos(roll), math.sin(roll)
+    cp, sp = math.cos(pitch), math.sin(pitch)
+    cy, sy = math.cos(yaw), math.sin(yaw)
+    return (
+        cy * cp,
+        cy * sp * sr - sy * cr,
+        cy * sp * cr + sy * sr,
+        sy * cp,
+        sy * sp * sr + cy * cr,
+        sy * sp * cr - cy * sr,
+        -sp,
+        cp * sr,
+        cp * cr,
+    )
+
+
+def matrix_to_rpy(matrix: Matrix3) -> RPY:
+    """Row-major rotation matrix to URDF extrinsic-XYZ RPY."""
+    m = tuple(matrix)
+    pitch = math.atan2(-m[6], math.sqrt(m[0] * m[0] + m[3] * m[3]))
+    if abs(math.cos(pitch)) > 1e-9:
+        roll = math.atan2(m[7], m[8])
+        yaw = math.atan2(m[3], m[0])
+    else:
+        # At gimbal lock choose yaw=0 and recover an equivalent roll.
+        roll = math.atan2(-m[5], m[4])
+        yaw = 0.0
+    return (roll, pitch, yaw)
+
+
+def mat3_mul(a: Matrix3, b: Matrix3) -> Matrix3:
+    return tuple(
+        sum(a[row * 3 + k] * b[k * 3 + col] for k in range(3))
+        for row in range(3)
+        for col in range(3)
+    )
+
+
+def mat3_transpose(matrix: Matrix3) -> Matrix3:
+    m = tuple(matrix)
+    return (m[0], m[3], m[6], m[1], m[4], m[7], m[2], m[5], m[8])
+
+
+def mat3_vec(matrix: Matrix3, vector: Vec3) -> Vec3:
+    m, v = tuple(matrix), tuple(vector)
+    return (
+        m[0] * v[0] + m[1] * v[1] + m[2] * v[2],
+        m[3] * v[0] + m[4] * v[1] + m[5] * v[2],
+        m[6] * v[0] + m[7] * v[1] + m[8] * v[2],
+    )
+
+
+def rotate_inertia(inertia: InertiaTensor, rotation: Matrix3) -> InertiaTensor:
+    """Return ``rotation * I * rotation^T`` for a symmetric tensor."""
+    source = (
+        inertia.ixx, inertia.ixy, inertia.ixz,
+        inertia.ixy, inertia.iyy, inertia.iyz,
+        inertia.ixz, inertia.iyz, inertia.izz,
+    )
+    result = mat3_mul(mat3_mul(rotation, source), mat3_transpose(rotation))
+    return InertiaTensor(
+        ixx=_clean(result[0]),
+        ixy=_clean(result[1]),
+        ixz=_clean(result[2]),
+        iyy=_clean(result[4]),
+        iyz=_clean(result[5]),
+        izz=_clean(result[8]),
+    )
+
+
+def _automatic_role(
+    model: RobotModel,
+    link_name: str,
+    joint: Optional[JointNode],
+    convention: str,
+) -> str:
+    if convention != "ros":
+        return "unchanged"
+    if link_name == model.root_link:
+        return "root_x_forward_z_up"
+    if joint and joint.joint_type in ("revolute", "continuous"):
+        return "revolute_axis_z"
+    return "unchanged"
+
+
+def _automatic_world_rotation(
+    model: RobotModel,
+    link_name: str,
+    joint: Optional[JointNode],
+    role: str,
+    old_world: Matrix3,
+    log=None,
+) -> Matrix3:
+    if role == "root_x_forward_z_up":
+        return IDENTITY_3
+    if role != "revolute_axis_z" or joint is None:
+        return old_world
+
+    axis_world = normalize(mat3_vec(old_world, tuple(joint.axis)))
+    if length(axis_world) < 1e-10:
+        _warn(log, f"Joint '{joint.name}' has a zero axis; keeping child frame")
+        return old_world
+
+    # Make X as close as possible to design-world forward while remaining
+    # perpendicular to the physical rotation axis.  If forward is parallel to
+    # the axis, use world Y (then world Z) as a deterministic fallback.
+    x_axis = _project_onto_plane((1.0, 0.0, 0.0), axis_world)
+    if length(x_axis) < 1e-8:
+        x_axis = _project_onto_plane((0.0, 1.0, 0.0), axis_world)
+    if length(x_axis) < 1e-8:
+        x_axis = _project_onto_plane((0.0, 0.0, 1.0), axis_world)
+    x_axis = normalize(x_axis)
+    y_axis = normalize(cross(axis_world, x_axis))
+    # Recompute X to remove accumulated projection error and guarantee a
+    # right-handed orthonormal basis: X x Y = Z.
+    x_axis = normalize(cross(y_axis, axis_world))
+    return _matrix_from_columns(x_axis, y_axis, axis_world)
+
+
+def _original_world_rotations(model: RobotModel) -> Dict[str, Matrix3]:
+    """Use Fusion source rotations, with zero-pose FK as a cache fallback."""
+    rotations: Dict[str, Matrix3] = {}
+    for name, link in model.links.items():
+        value = getattr(link, "source_world_rotation", None)
+        if value is not None and len(value) == 9:
+            rotations[name] = tuple(float(v) for v in value)
+
+    # Old caches/synthetic tests may not carry source rotations.  Derive their
+    # URDF zero-pose rotations, rooted at identity.
+    rotations.setdefault(model.root_link, IDENTITY_3)
+    remaining = list(model.joints.values())
+    progress = True
+    while remaining and progress:
+        progress = False
+        next_remaining = []
+        for joint in remaining:
+            if joint.parent_link not in rotations:
+                next_remaining.append(joint)
+                continue
+            rotations.setdefault(
+                joint.child_link,
+                mat3_mul(rotations[joint.parent_link], rpy_to_matrix(tuple(joint.origin_rpy))),
+            )
+            progress = True
+        remaining = next_remaining
+    for name in model.links:
+        rotations.setdefault(name, IDENTITY_3)
+    return rotations
+
+
+def _post_rpy_degrees(row: dict, link_name: str, log=None) -> Optional[Vec3]:
+    values = []
+    for key in ("post_roll_deg", "post_pitch_deg", "post_yaw_deg"):
+        raw = row.get(key, "")
+        try:
+            value = float(raw)
+        except (TypeError, ValueError):
+            _warn(log, f"Frame '{link_name}': {key}={raw!r} is not a number")
+            return None
+        if not math.isfinite(value):
+            _warn(log, f"Frame '{link_name}': {key} must be finite")
+            return None
+        values.append(value)
+    return (values[0], values[1], values[2])
+
+
+def _all_joints(model: RobotModel) -> Iterable[JointNode]:
+    yield from model.joints.values()
+    yield from getattr(model, "closing_joints", {}).values()
+
+
+def _model_from_dict(data: dict) -> RobotModel:
+    model = RobotModel(
+        name=data.get("name", ""),
+        root_link=data.get("root_link", ""),
+        warnings=list(data.get("warnings", [])),
+        errors=list(data.get("errors", [])),
+    )
+    model.links = {
+        name: _link_from_dict(item)
+        for name, item in data.get("links", {}).items()
+    }
+    model.joints = {
+        name: _joint_from_dict(item)
+        for name, item in data.get("joints", {}).items()
+    }
+    model.closing_joints = {
+        name: _joint_from_dict(item)
+        for name, item in data.get("closing_joints", {}).items()
+    }
+    model.assemblies = {
+        name: AssemblyInfo(**_filtered_kwargs(AssemblyInfo, item))
+        for name, item in data.get("assemblies", {}).items()
+    }
+    return model
+
+
+def _link_from_dict(data: dict) -> LinkNode:
+    item = dict(data)
+    inertia = item.pop("inertia_at_com", {}) or {}
+    collision = item.pop("collision", None)
+    link = LinkNode(**_filtered_kwargs(LinkNode, item))
+    link.inertia_at_com = InertiaTensor(**_filtered_kwargs(InertiaTensor, inertia))
+    if collision:
+        link.collision = _collision_from_dict(collision)
+    return link
+
+
+def _collision_from_dict(data: dict) -> CollisionInfo:
+    item = dict(data)
+    primitive = item.pop("primitive", None)
+    collision = CollisionInfo(**_filtered_kwargs(CollisionInfo, item))
+    if primitive:
+        collision.primitive = CollisionPrimitive(
+            **_filtered_kwargs(CollisionPrimitive, primitive)
+        )
+    return collision
+
+
+def _joint_from_dict(data: dict) -> JointNode:
+    item = dict(data)
+    limits = item.pop("limits", None)
+    joint = JointNode(**_filtered_kwargs(JointNode, item))
+    if limits:
+        joint.limits = JointLimits(**_filtered_kwargs(JointLimits, limits))
+    return joint
+
+
+def _config_from_dict(data: dict) -> ExportConfig:
+    config = ExportConfig(**_filtered_kwargs(ExportConfig, data))
+    config.ros2_control_command_interfaces = tuple(
+        config.ros2_control_command_interfaces
+    )
+    return config
+
+
+def _filtered_kwargs(cls, data: dict) -> dict:
+    allowed = {field.name for field in fields(cls)}
+    return {key: value for key, value in data.items() if key in allowed}
+
+
+def _matrix_from_columns(x_axis: Vec3, y_axis: Vec3, z_axis: Vec3) -> Matrix3:
+    return (
+        x_axis[0], y_axis[0], z_axis[0],
+        x_axis[1], y_axis[1], z_axis[1],
+        x_axis[2], y_axis[2], z_axis[2],
+    )
+
+
+def _project_onto_plane(vector: Vec3, normal: Vec3) -> Vec3:
+    scale = dot(vector, normal)
+    return (
+        vector[0] - scale * normal[0],
+        vector[1] - scale * normal[1],
+        vector[2] - scale * normal[2],
+    )
+
+
+def vec_add(a: Vec3, b: Vec3) -> Vec3:
+    return (a[0] + b[0], a[1] + b[1], a[2] + b[2])
+
+
+def dot(a: Vec3, b: Vec3) -> float:
+    return a[0] * b[0] + a[1] * b[1] + a[2] * b[2]
+
+
+def cross(a: Vec3, b: Vec3) -> Vec3:
+    return (
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    )
+
+
+def length(vector: Vec3) -> float:
+    return math.sqrt(dot(vector, vector))
+
+
+def normalize(vector: Vec3) -> Vec3:
+    magnitude = length(vector)
+    if magnitude < 1e-12:
+        return (0.0, 0.0, 0.0)
+    return (
+        vector[0] / magnitude,
+        vector[1] / magnitude,
+        vector[2] / magnitude,
+    )
+
+
+def _matrix_close(a: Matrix3, b: Matrix3, tol: float = 1e-9) -> bool:
+    return all(abs(float(x) - float(y)) <= tol for x, y in zip(a, b))
+
+
+def _vec_close(a: Vec3, b: Vec3, tol: float = 1e-9) -> bool:
+    return all(abs(float(x) - float(y)) <= tol for x, y in zip(a, b))
+
+
+def _clean(value: float, tol: float = 1e-12) -> float:
+    if abs(value) < tol:
+        return 0.0
+    if abs(value - 1.0) < tol:
+        return 1.0
+    if abs(value + 1.0) < tol:
+        return -1.0
+    return float(value)
+
+
+def _clean_vec(vector: Vec3) -> Vec3:
+    return (_clean(vector[0]), _clean(vector[1]), _clean(vector[2]))
+
+
+def _fmt_deg(value: float) -> str:
+    cleaned = _clean(value, tol=5e-10)
+    return f"{cleaned:.6f}"
+
+
+def _info(log, message: str) -> None:
+    if log is not None:
+        log(message)
+
+
+def _warn(log, message: str) -> None:
+    if log is None:
+        return
+    warning = getattr(log, "warning", None)
+    if callable(warning):
+        warning(message)
+    else:
+        log(f"WARNING: {message}")

--- a/core/fusion_extractor.py
+++ b/core/fusion_extractor.py
@@ -2971,8 +2971,9 @@ def _export_merged_visual_obj(
         # link's frame is the ANCHOR's component frame.  When the anchor
         # is placed at identity within the LCA (the typical case — pendel
         # in pendel_with_esp), no correction is needed.  Otherwise,
-        # transform vertices using the anchor's local transform to
-        # express them in anchor-local coordinates.
+        # derive the anchor pose relative to that LCA from both
+        # occurrences' design-world transforms, then express the vertices
+        # in anchor-local coordinates.
         _maybe_apply_anchor_frame_correction(
             obj_path, anchor_occ, lca_path, snapshot, log,
         )
@@ -3004,14 +3005,67 @@ def _maybe_apply_anchor_frame_correction(
     Solving for v_anchor:
         v_anchor = R_anchor_in_LCAᵀ · (v_LCA - t_anchor_in_LCA)
     """
-    # Compute anchor's pose relative to LCA.  When LCA is rootComponent
-    # (lca_path == ""), use the anchor's transform2 (which is in root
-    # frame).  Otherwise, compute (LCA_transform2)⁻¹ · anchor_transform2
-    # — but in practice the simpler check below covers the cases we hit.
-    if anchor_occ.local_transform is None:
+    # Compute the anchor pose in the frame Fusion used for the OBJ.  A
+    # nested occurrence's ``local_transform`` is relative to its immediate
+    # parent, which is not necessarily the merge LCA.  In particular, a
+    # root-spanning rigid group is exported in the design-root frame, so
+    # using that nested local transform can move the mesh metres away.
+    # ``transform2`` gives both occurrences in the design frame; compose
+    # LCA_world⁻¹ · anchor_world to get the exact pose needed here.
+    anchor_world = getattr(anchor_occ, "transform2", None)
+    if anchor_world is not None and not lca_path:
+        t_loc = anchor_world.translation
+        r_loc = anchor_world.rotation
+    elif anchor_world is not None:
+        lca_occ = snapshot.occurrences.get(lca_path)
+        lca_world = getattr(lca_occ, "transform2", None) if lca_occ else None
+        if lca_world is not None:
+            from .robot_model import (
+                _mat3_mul, _mat3_transpose, _rotate_vec3_by_mat3,
+                _vec_sub,
+            )
+
+            r_lca_inv = _mat3_transpose(lca_world.rotation)
+            t_loc = _rotate_vec3_by_mat3(
+                _vec_sub(anchor_world.translation, lca_world.translation),
+                r_lca_inv,
+            )
+            r_loc = _mat3_mul(r_lca_inv, anchor_world.rotation)
+        else:
+            local = getattr(anchor_occ, "local_transform", None)
+            if local is None:
+                log.warning(
+                    "    Cannot correct merged OBJ into anchor frame: "
+                    f"LCA '{lca_path}' and anchor lack usable transforms"
+                )
+                return
+            log.warning(
+                "    Merge LCA lacks transform2; falling back to the "
+                "anchor's immediate-parent local transform"
+            )
+            t_loc = local.translation
+            r_loc = local.rotation
+    else:
+        local = getattr(anchor_occ, "local_transform", None)
+        if local is None:
+            log.warning(
+                "    Cannot correct merged OBJ into anchor frame: anchor "
+                "lacks transform2 and local_transform"
+            )
+            return
+        log.warning(
+            "    Merge anchor lacks transform2; falling back to its local "
+            "transform"
+        )
+        t_loc = local.translation
+        r_loc = local.rotation
+
+    if not r_loc or len(r_loc) != 9:
+        log.warning(
+            "    Cannot correct merged OBJ into anchor frame: invalid "
+            "anchor rotation"
+        )
         return
-    t_loc = anchor_occ.local_transform.translation
-    r_loc = anchor_occ.local_transform.rotation
 
     is_identity = (
         abs(t_loc[0]) < 1e-9 and abs(t_loc[1]) < 1e-9 and abs(t_loc[2]) < 1e-9

--- a/core/package_generator.py
+++ b/core/package_generator.py
@@ -30,6 +30,11 @@ from datetime import datetime
 from .data_types import RobotModel, ExportConfig
 from .xacro_generator import generate_urdf
 from .collision_generator import resolve_collision, generate_collision_meshes
+from .frame_rebaser import (
+    FRAME_CACHE_FILENAME,
+    configure_frames,
+    save_frame_cache,
+)
 from .xacro_generator import generate_xacro_package
 from .ros2_control_generator import (
     command_interfaces,
@@ -82,10 +87,15 @@ def generate_package(
     ]
     if getattr(config, "include_launch", True):
         dirs.append(os.path.join(pkg_dir, "launch"))
+    emit_frame_artifacts = (
+        str(getattr(config, "verbosity", "verbose")).strip().lower()
+        != "minimal"
+    )
     if getattr(config, "include_rviz", True):
         dirs.append(os.path.join(pkg_dir, "rviz"))
     if (getattr(config, "include_rviz", True)
-            or ros2_control_enabled(config, model)):
+            or ros2_control_enabled(config, model)
+            or emit_frame_artifacts):
         dirs.append(os.path.join(pkg_dir, "config"))
 
     for d in dirs:
@@ -96,14 +106,31 @@ def generate_package(
     
     # 2. Generate collision STL files from automatic collision methods
     generate_collision_meshes(model, pkg_dir, log)
+
+    # 3. Cache the canonical collision-resolved model, then apply the
+    # orientation-only frame layer.  The cache makes CSV edits replayable
+    # without another slow Fusion extraction or mesh export.
+    log.section("PACKAGE: FRAMES")
+    frame_cache_path = os.path.join(
+        config.output_dir, "debug", FRAME_CACHE_FILENAME
+    )
+    save_frame_cache(model, config, frame_cache_path)
+    log(f"  -> debug/{FRAME_CACHE_FILENAME} (pre-frame cache)")
+    configure_frames(
+        model,
+        config,
+        pkg_dir,
+        log,
+        emit_artifacts=emit_frame_artifacts,
+    )
     
-    # 3. Generate xacro files (hierarchical)
+    # 4. Generate xacro files (hierarchical)
     log.section("PACKAGE: XACRO")
     xacro_files = generate_xacro_package(model, config, pkg_dir)
     for rel_path in sorted(xacro_files.keys()):
         log(f"  → {rel_path}")
     
-    # 4. Also generate flat URDF for validation/debugging
+    # 5. Also generate flat URDF for validation/debugging
     log.section("PACKAGE: URDF (flat, for validation)")
     urdf_xml = generate_urdf(model, config)
     urdf_path = os.path.join(pkg_dir, "urdf", f"{model.name}.urdf")
@@ -236,6 +263,64 @@ def generate_package(
         log(f"  Launch: ros2 launch {config.package_name} display.launch.py")
 
     return pkg_dir
+
+
+def regenerate_frame_outputs(
+    model: RobotModel,
+    config: ExportConfig,
+    pkg_dir: str,
+    log: Logger,
+) -> None:
+    """Rewrite frame-dependent outputs from a cached canonical model.
+
+    Mesh and collision generation are deliberately skipped.  ``model`` must
+    already have collision information and frame rebases applied (normally by
+    ``tools/reframe.py`` after loading ``debug/frame_model.json``).
+    """
+    os.makedirs(os.path.join(pkg_dir, "urdf", "assemblies"), exist_ok=True)
+    os.makedirs(os.path.join(pkg_dir, "config"), exist_ok=True)
+
+    log.section("OFFLINE FRAMES: XACRO + URDF")
+    xacro_files = generate_xacro_package(model, config, pkg_dir)
+    for rel_path in sorted(xacro_files):
+        log(f"  -> {rel_path}")
+
+    urdf_xml = generate_urdf(model, config)
+    urdf_path = os.path.join(pkg_dir, "urdf", f"{model.name}.urdf")
+    _write_file(urdf_path, urdf_xml)
+    log(f"  -> urdf/{model.name}.urdf")
+
+    if getattr(config, "include_rviz", True):
+        _write_file(
+            os.path.join(pkg_dir, "config", "joint_state.yaml"),
+            _generate_joint_config(model, config),
+        )
+        log("  -> config/joint_state.yaml")
+
+    if ros2_control_enabled(config, model):
+        _write_file(
+            os.path.join(pkg_dir, "config", "ros2_controllers.yaml"),
+            generate_ros2_controllers_yaml(model, config),
+        )
+        log("  -> config/ros2_controllers.yaml")
+
+    yaml_required = (
+        getattr(config, "include_robot_data_yaml", True)
+        or bool(getattr(model, "closing_joints", None))
+    )
+    docs_required = getattr(config, "include_docs", True)
+    if yaml_required or docs_required:
+        from .supplementary_export import (
+            generate_supplementary_yaml,
+            generate_transforms_doc,
+        )
+        if yaml_required:
+            generate_supplementary_yaml(model, config, pkg_dir, log)
+        if docs_required:
+            generate_transforms_doc(model, pkg_dir, log)
+
+    if getattr(config, "include_readme", True):
+        _generate_robot_readme(model, config, pkg_dir, log)
 
 
 def generate_validation_report(model: RobotModel, config: ExportConfig, debug_dir: str):
@@ -447,8 +532,13 @@ def _generate_cmake(model: RobotModel, config: ExportConfig) -> str:
         install_dirs.append("launch")
     if getattr(config, "include_rviz", True):
         install_dirs.append("rviz")
+    emit_frame_artifacts = (
+        str(getattr(config, "verbosity", "verbose")).strip().lower()
+        != "minimal"
+    )
     if (getattr(config, "include_rviz", True)
-            or ros2_control_enabled(config, model)):
+            or ros2_control_enabled(config, model)
+            or emit_frame_artifacts):
         install_dirs.append("config")
     return f"""cmake_minimum_required(VERSION 3.8)
 project({config.package_name})

--- a/core/robot_model.py
+++ b/core/robot_model.py
@@ -261,7 +261,7 @@ def build_model(snapshot: FusionSnapshot, log: Logger) -> RobotModel:
     _drop_unreferenced_empty_occurrences(snapshot, occ_to_asm, edges, model, log)
     
     log.section("MODEL: DETECT ROOT")
-    root_asm, root_comp = _detect_root(edges, model, log)
+    root_asm, root_comp = _detect_root(edges, snapshot, occ_to_asm, model, log)
     
     log.section("MODEL: RESOLVE NAMES")
     name_map = _resolve_names(snapshot, occ_to_asm, root_asm, root_comp, model, log)
@@ -1240,12 +1240,14 @@ def _resolve_joint_paths(
         p_asm, p_comp, p_path = _resolve_occ_path(
             fj.occurrence_two_path, fj.occurrence_two_clean,
             defining, snapshot, occ_to_asm, redirects, member_to_anchor,
+            log,
         )
 
         # Resolve child (occurrenceOne)
         c_asm, c_comp, c_path = _resolve_occ_path(
             fj.occurrence_one_path, fj.occurrence_one_clean,
             defining, snapshot, occ_to_asm, redirects, member_to_anchor,
+            log,
         )
 
         # Drop joints internal to a rigid group.  Use full_path
@@ -1412,6 +1414,7 @@ def _resolve_occ_path(
     occ_to_asm: Dict[str, str],
     redirects: Optional[Dict[str, str]] = None,
     member_to_anchor: Optional[Dict[str, Tuple[str, str, str]]] = None,
+    log: Optional[Logger] = None,
 ) -> Tuple[str, str, str]:
     """
     Resolve a joint's local occurrence path to (assembly, component, full_path).
@@ -1430,8 +1433,10 @@ def _resolve_occ_path(
          collapsed into a rigid-group anchor.  Find the leaf's
          full_path in ``snapshot.occurrences``, look up the redirect
          by full_path, and return the anchor's (asm, clean, full_path).
-      4. Fallback: suffix-only match in occ_to_asm.
-      5. Last resort: defining component as assembly, full_path empty.
+      4. If the target is a container-only subassembly, redirect to that
+         subassembly's deterministic URDF root link.
+      5. Fallback: suffix-only match in occ_to_asm.
+      6. Last resort: defining component as assembly, full_path empty.
     """
     # Check redirect: joint targets a flattened collision sub-assembly
     if redirects and clean in redirects:
@@ -1470,6 +1475,14 @@ def _resolve_occ_path(
                 anchor_path, anchor_asm, anchor_clean = redirected
                 return anchor_asm, anchor_clean, anchor_path
 
+    # Joint endpoint may target a subassembly container. URDF has no
+    # container node, so use that subassembly's deterministic root link.
+    subasm_endpoint = _resolve_subassembly_endpoint(
+        local_path, clean, snapshot, occ_to_asm, member_to_anchor, log
+    )
+    if subasm_endpoint is not None:
+        return subasm_endpoint
+
     # No match by name+suffix — try suffix only
     for full_path, asm in occ_to_asm.items():
         if full_path.endswith(local_path):
@@ -1481,36 +1494,283 @@ def _resolve_occ_path(
     return defining_component, clean, ""
 
 
+def _resolve_subassembly_endpoint(
+    local_path: str,
+    clean: str,
+    snapshot: FusionSnapshot,
+    occ_to_asm: Dict[str, str],
+    member_to_anchor: Optional[Dict[str, Tuple[str, str, str]]] = None,
+    log: Optional[Logger] = None,
+) -> Optional[Tuple[str, str, str]]:
+    """Map a container subassembly joint endpoint to its URDF root link.
+
+    Fusion allows joints to target a subassembly occurrence. URDF has no
+    corresponding container node, so resolve that endpoint to a real link
+    inside the subassembly when the choice is deterministic:
+
+      * one surviving link candidate under the subassembly,
+      * one parent-only internal joint root under the subassembly, or
+      * one conventional root name (base_link, body_link, root_link) among
+        those root candidates.
+    """
+    if local_path == DESIGN_ROOT_OCCURRENCE_PATH:
+        return None
+
+    subasm = _find_subassembly_occurrence(local_path, clean, snapshot)
+    if subasm is None:
+        return None
+
+    subasm_path, subasm_occ = subasm
+    candidate_paths = _subassembly_link_candidate_paths(subasm_path, occ_to_asm)
+    if not candidate_paths:
+        return None
+
+    chosen = None
+    reason = ""
+    if len(candidate_paths) == 1:
+        chosen = candidate_paths[0]
+        reason = "single link candidate"
+    else:
+        root_paths = _subassembly_internal_root_paths(
+            subasm_path, candidate_paths, snapshot, member_to_anchor
+        )
+        if len(root_paths) == 1:
+            chosen = root_paths[0]
+            reason = "internal joint root"
+        else:
+            chosen = _pick_conventional_subassembly_root(
+                root_paths or candidate_paths, snapshot
+            )
+            if chosen:
+                reason = "conventional root name"
+
+    if chosen is None:
+        if log:
+            names = [
+                snapshot.occurrences[p].clean_name
+                for p in candidate_paths
+                if p in snapshot.occurrences
+            ]
+            log.warning(
+                f"Subassembly endpoint '{subasm_occ.clean_name}' is ambiguous; "
+                f"candidate links: {names}"
+            )
+        return None
+
+    occ = snapshot.occurrences.get(chosen)
+    asm = occ_to_asm.get(chosen)
+    if occ is None or asm is None:
+        return None
+
+    if log:
+        log(
+            f"  subassembly endpoint {subasm_occ.clean_name} ({subasm_path}) "
+            f"-> {asm}/{occ.clean_name} [{reason}]"
+        )
+    return asm, occ.clean_name, chosen
+
+
+def _find_subassembly_occurrence(
+    local_path: str,
+    clean: str,
+    snapshot: FusionSnapshot,
+) -> Optional[Tuple[str, FusionOccurrence]]:
+    """Find the subassembly occurrence named by a joint endpoint."""
+    matches: List[Tuple[str, FusionOccurrence]] = []
+    for full_path, occ in snapshot.occurrences.items():
+        if full_path == DESIGN_ROOT_OCCURRENCE_PATH:
+            continue
+        if not occ.is_subassembly:
+            continue
+        if clean and occ.clean_name != clean:
+            continue
+        if full_path == local_path or (local_path and full_path.endswith(local_path)):
+            matches.append((full_path, occ))
+
+    if not matches:
+        return None
+
+    matches.sort(key=lambda item: (item[0] != local_path, item[1].depth, item[0]))
+    return matches[0]
+
+
+def _subassembly_link_candidate_paths(
+    subasm_path: str,
+    occ_to_asm: Dict[str, str],
+) -> List[str]:
+    """Surviving URDF link candidate paths inside a subassembly."""
+    return sorted(
+        path for path in occ_to_asm
+        if path != subasm_path and _path_is_descendant_or_self(path, subasm_path)
+    )
+
+
+def _subassembly_internal_root_paths(
+    subasm_path: str,
+    candidate_paths: List[str],
+    snapshot: FusionSnapshot,
+    member_to_anchor: Optional[Dict[str, Tuple[str, str, str]]] = None,
+) -> List[str]:
+    """Return parent-only internal joint roots among candidate links."""
+    candidate_set = set(candidate_paths)
+    parents: Set[str] = set()
+    children: Set[str] = set()
+
+    for fj in snapshot.joints.values():
+        p_path = _resolve_endpoint_path_within_subassembly(
+            fj.occurrence_two_path, fj.occurrence_two_clean,
+            subasm_path, candidate_set, snapshot, member_to_anchor,
+        )
+        c_path = _resolve_endpoint_path_within_subassembly(
+            fj.occurrence_one_path, fj.occurrence_one_clean,
+            subasm_path, candidate_set, snapshot, member_to_anchor,
+        )
+        if not p_path or not c_path or p_path == c_path:
+            continue
+        parents.add(p_path)
+        children.add(c_path)
+
+    return sorted(parents - children)
+
+
+def _resolve_endpoint_path_within_subassembly(
+    local_path: str,
+    clean: str,
+    subasm_path: str,
+    candidate_set: Set[str],
+    snapshot: FusionSnapshot,
+    member_to_anchor: Optional[Dict[str, Tuple[str, str, str]]] = None,
+) -> Optional[str]:
+    """Resolve one joint endpoint to a candidate path inside a subassembly."""
+    matches = []
+    for path in candidate_set:
+        occ = snapshot.occurrences.get(path)
+        if not occ:
+            continue
+        if clean and occ.clean_name != clean:
+            continue
+        if local_path and path.endswith(local_path):
+            matches.append(path)
+
+    if len(matches) == 1:
+        return matches[0]
+
+    if member_to_anchor:
+        redirected = []
+        for path, occ in snapshot.occurrences.items():
+            if not _path_is_descendant_or_self(path, subasm_path):
+                continue
+            if clean and occ.clean_name != clean:
+                continue
+            if not (local_path and path.endswith(local_path)):
+                continue
+            anchor = member_to_anchor.get(path)
+            if anchor and anchor[0] in candidate_set:
+                redirected.append(anchor[0])
+        redirected_unique = sorted(set(redirected))
+        if len(redirected_unique) == 1:
+            return redirected_unique[0]
+
+    return None
+
+
+def _pick_conventional_subassembly_root(
+    paths: List[str],
+    snapshot: FusionSnapshot,
+) -> Optional[str]:
+    """Pick a conventional root-name link when exactly one is present."""
+    preferred_names = ("base_link", "body_link", "root_link")
+    for name in preferred_names:
+        matches = [
+            path for path in paths
+            if (occ := snapshot.occurrences.get(path)) is not None
+            and occ.clean_name == name
+        ]
+        if len(matches) == 1:
+            return matches[0]
+    return None
+
+
 # ──────────────────────────────────────────────
 # Step 3: Detect root link
 # ──────────────────────────────────────────────
 
+def _pick_jointless_root(
+    snapshot: FusionSnapshot,
+    occ_to_asm: Dict[str, str],
+) -> Optional[Tuple[str, str]]:
+    """Pick a root for a design with no kinematic edges (no joints).
+
+    Prefers a conventional root-name link; otherwise falls back to the
+    first link-candidate occurrence in stable full_path order.  Returns
+    None only when there are no link candidates at all.
+    """
+    candidates = [
+        (path, snapshot.occurrences[path])
+        for path in sorted(
+            (p for p in snapshot.occurrences
+             if p in occ_to_asm
+             and _occurrence_is_link_candidate(snapshot.occurrences[p])),
+            key=lambda p: snapshot.occurrences[p].full_path or p,
+        )
+    ]
+    if not candidates:
+        return None
+
+    preferred_names = ("base_link", "body_link", "root_link")
+    for name in preferred_names:
+        for path, occ in candidates:
+            if occ.clean_name == name:
+                return (occ_to_asm[path], occ.clean_name)
+
+    path, occ = candidates[0]
+    return (occ_to_asm[path], occ.clean_name)
+
+
 def _detect_root(
     edges: List[KinematicEdge],
+    snapshot: FusionSnapshot,
+    occ_to_asm: Dict[str, str],
     model: RobotModel,
     log: Logger,
 ) -> Tuple[str, str]:
     """
     Find root link: appears as parent but never as child, with most descendants.
-    
+
     Returns:
         (assembly_name, component_name) of root
     """
+    # No joints at all — single rigid body (or several jointless links).
+    # There are no edges to derive a root from, so pick one directly from
+    # the link-candidate occurrences.  Common when exporting a standalone
+    # part (e.g. a camera body) that will be assembled elsewhere.
+    if not edges:
+        root = _pick_jointless_root(snapshot, occ_to_asm)
+        if root is None:
+            model.errors.append("No links found — nothing to export as a root")
+            raise ValueError("No exportable links: design has no joints and no link candidates")
+        model.warnings.append(
+            f"No joints found — exporting '{root[1]}' as a single root link. "
+            f"Add joints in Fusion if you expect a multi-link kinematic chain."
+        )
+        log.warning(f"No joints — single-link export, root: {root[0]}/{root[1]}")
+        return root
+
     # Collect all parent and child identities
     all_parents: Set[Tuple[str, str]] = set()
     all_children: Set[Tuple[str, str]] = set()
-    
+
     for e in edges:
         all_parents.add((e.parent_asm, e.parent_comp))
         all_children.add((e.child_asm, e.child_comp))
-    
+
     # Root candidates: parent but never child
     roots = all_parents - all_children
-    
+
     log(f"  Parent-only nodes: {len(roots)}")
     for r in roots:
         log(f"    {r[0]}/{r[1]}")
-    
+
     if len(roots) == 0:
         model.errors.append("No root found — kinematic chain has a cycle")
         # Fallback: pick the node with most outgoing edges
@@ -1833,6 +2093,12 @@ def _build_links(
                 # Store the collision occurrence path for mesh export
                 link._collision_sibling_path = flatten_pairs[occ.clean_name]
                 log(f"  {urdf_name}: explicit collision from flattened sibling")
+
+        # Preserve the authoritative orientation of this link's source
+        # occurrence in Fusion design-world coordinates.  Phase 3 can then
+        # rebase the exported frame (for ROS X-forward/Z-up and joint-axis
+        # conventions) without reaching back into the Fusion API.
+        link.source_world_rotation = _global_rotation_for_occurrence(path, snapshot)
 
         model.links[urdf_name] = link
 

--- a/core/snapshot_io.py
+++ b/core/snapshot_io.py
@@ -1,0 +1,98 @@
+"""Pure-Python deserialization for ``debug/snapshot.json``.
+
+The exporter already serializes dataclasses generically.  This module provides
+the inverse operation so model-building and frame tests can run from cached
+Fusion extraction data, including authoritative ``transform2`` rotations.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import fields
+from typing import Optional
+
+from .data_types import (
+    FusionBodyInfo,
+    FusionJoint,
+    FusionOccurrence,
+    FusionSnapshot,
+    InertiaTensor,
+    RigidGroupInfo,
+    Transform3D,
+)
+
+
+def load_snapshot(path: str) -> FusionSnapshot:
+    with open(path, "r", encoding="utf-8") as handle:
+        return snapshot_from_dict(json.load(handle))
+
+
+def snapshot_from_dict(data: dict) -> FusionSnapshot:
+    item = dict(data)
+    occurrences = item.pop("occurrences", {}) or {}
+    joints = item.pop("joints", {}) or {}
+    rigid_groups = item.pop("rigid_groups", []) or []
+    snapshot = FusionSnapshot(**_filtered_kwargs(FusionSnapshot, item))
+    snapshot.occurrences = {
+        path: _occurrence_from_dict(value)
+        for path, value in occurrences.items()
+    }
+    snapshot.joints = {
+        name: FusionJoint(**_filtered_kwargs(FusionJoint, value))
+        for name, value in joints.items()
+    }
+    snapshot.rigid_groups = [
+        RigidGroupInfo(**_filtered_kwargs(RigidGroupInfo, value))
+        for value in rigid_groups
+    ]
+    return snapshot
+
+
+def _occurrence_from_dict(data: dict) -> FusionOccurrence:
+    item = dict(data)
+    local_transform = item.pop("local_transform", None)
+    transform2 = item.pop("transform2", None)
+    global_transform = item.pop("global_transform", None)
+    inertia_origin = item.pop("inertia_at_origin", None)
+    inertia_com = item.pop("inertia_at_com", None)
+    bodies = item.pop("bodies", []) or []
+
+    occurrence = FusionOccurrence(**_filtered_kwargs(FusionOccurrence, item))
+    occurrence.local_transform = _transform_from_dict(local_transform) or Transform3D()
+    occurrence.transform2 = _transform_from_dict(transform2)
+    occurrence.global_transform = _transform_from_dict(global_transform) or Transform3D()
+    occurrence.inertia_at_origin = _inertia_from_dict(inertia_origin) or InertiaTensor()
+    occurrence.inertia_at_com = _inertia_from_dict(inertia_com) or InertiaTensor()
+    occurrence.bodies = [_body_from_dict(value) for value in bodies]
+    return occurrence
+
+
+def _body_from_dict(data: dict) -> FusionBodyInfo:
+    item = dict(data)
+    inertia = item.pop("inertia_at_origin", None)
+    body = FusionBodyInfo(**_filtered_kwargs(FusionBodyInfo, item))
+    body.inertia_at_origin = _inertia_from_dict(inertia)
+    return body
+
+
+def _transform_from_dict(data: Optional[dict]) -> Optional[Transform3D]:
+    if not data:
+        return None
+    translation = tuple(data.get("translation", (0.0, 0.0, 0.0)))
+    rotation = data.get("rotation", (1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
+    if rotation and isinstance(rotation[0], (list, tuple)):
+        rotation = tuple(value for row in rotation for value in row)
+    else:
+        rotation = tuple(rotation)
+    return Transform3D(translation=translation, rotation=rotation)
+
+
+def _inertia_from_dict(data: Optional[dict]) -> Optional[InertiaTensor]:
+    if not data:
+        return None
+    return InertiaTensor(**_filtered_kwargs(InertiaTensor, data))
+
+
+def _filtered_kwargs(cls, data: dict) -> dict:
+    allowed = {field.name for field in fields(cls)}
+    return {key: value for key, value in data.items() if key in allowed}

--- a/core/supplementary_export.py
+++ b/core/supplementary_export.py
@@ -124,6 +124,20 @@ def generate_supplementary_yaml(
         if link.needs_mesh_bake:
             bk = link.mesh_bake_offset
             lines.append(f"    bake_offset_m: [{bk[0]:.6f}, {bk[1]:.6f}, {bk[2]:.6f}]")
+            mr = getattr(link, "mesh_origin_rpy", (0.0, 0.0, 0.0))
+            lines.append(
+                f"    mesh_origin_rpy_rad: "
+                f"[{mr[0]:.6f}, {mr[1]:.6f}, {mr[2]:.6f}]"
+            )
+
+        frame_rule = getattr(link, "frame_rule", "keep")
+        if frame_rule != "keep":
+            fr = getattr(link, "frame_rebase_rpy", (0.0, 0.0, 0.0))
+            lines.append(f"    frame_rule: {frame_rule}")
+            lines.append(
+                f"    frame_rebase_rpy_rad: "
+                f"[{fr[0]:.6f}, {fr[1]:.6f}, {fr[2]:.6f}]"
+            )
         
         if link.rigid_group_name:
             lines.append(f"    rigid_group: {yaml_safe_name(link.rigid_group_name)}")

--- a/core/user_config.py
+++ b/core/user_config.py
@@ -217,6 +217,10 @@ def apply_to_config(cfg, toml_data: Dict[str, Dict[str, Any]]) -> list:
         collision_method = "primitive"   # or "convex_hull" / "visual_reuse"
         mesh_refinement = "medium"       # low / medium / high
 
+        [frames]
+        convention = "ros"      # root X-forward/Z-up; revolute axis +Z
+        overrides_file = "frame_overrides.csv"
+
         [ros2_control]
         hardware_plugin = "mock_components/GenericSystem"
         update_rate = 100
@@ -230,6 +234,7 @@ def apply_to_config(cfg, toml_data: Dict[str, Dict[str, Any]]) -> list:
     output = toml_data.get("output", {}) or {}
     features = toml_data.get("features", {}) or {}
     mesh = toml_data.get("mesh", {}) or {}
+    frames_cfg = toml_data.get("frames", {}) or {}
     ros2_control = toml_data.get("ros2_control", {}) or {}
 
     # Verbosity drives default include_* values; explicit [features]
@@ -267,6 +272,19 @@ def apply_to_config(cfg, toml_data: Dict[str, Dict[str, Any]]) -> list:
     if "mesh_refinement" in mesh and isinstance(mesh["mesh_refinement"], str):
         cfg.mesh_refinement = mesh["mesh_refinement"].lower().strip()
         changes.append(f"mesh_refinement = {cfg.mesh_refinement}")
+
+    if "convention" in frames_cfg and isinstance(frames_cfg["convention"], str):
+        cfg.frame_convention = frames_cfg["convention"].lower().strip()
+        changes.append(f"frames.convention = {cfg.frame_convention}")
+    if "overrides_file" in frames_cfg and isinstance(frames_cfg["overrides_file"], str):
+        # Keep the generated/editable CSV inside package config/.  A basename
+        # also prevents a personal TOML from escaping the export directory.
+        cfg.frame_overrides_filename = os.path.basename(
+            frames_cfg["overrides_file"].strip()
+        ) or "frame_overrides.csv"
+        changes.append(
+            f"frames.overrides_file = {cfg.frame_overrides_filename}"
+        )
 
     if "hardware_plugin" in ros2_control and isinstance(ros2_control["hardware_plugin"], str):
         cfg.ros2_control_hardware_plugin = ros2_control["hardware_plugin"].strip()

--- a/core/xacro_generator.py
+++ b/core/xacro_generator.py
@@ -17,6 +17,7 @@ Author: Adrian Valaker Eikeland
 
 import math
 import os
+import re
 import xml.dom.minidom
 from typing import Dict, List, Optional, Set
 
@@ -203,7 +204,7 @@ def _generate_top_level_xacro(
     # Instantiate macros
     lines.append('  <!-- Instantiate assemblies -->')
     for asm_name in assembly_names:
-        lines.append(f'  <xacro:{asm_name} prefix=""/>')
+        lines.append(f'  <xacro:{_xacro_macro_name(asm_name)} prefix=""/>')
     lines.append('')
     
     # Mount joints (cross-assembly connections)
@@ -251,7 +252,7 @@ def _generate_assembly_xacro(
     lines.append('<?xml version="1.0"?>')
     lines.append(f'<robot xmlns:xacro="{XACRO_NS}" name="{asm_name}_macro">')
     lines.append('')
-    lines.append(f'  <xacro:macro name="{asm_name}" params="prefix">')
+    lines.append(f'  <xacro:macro name="{_xacro_macro_name(asm_name)}" params="prefix">')
     lines.append('')
     
     # Sort links: root-like first (by position in kinematic chain)
@@ -332,16 +333,20 @@ def _generate_link_xml(
     # Bake offset: shift from joint frame to component origin
     # Applied to visual, inertial, and collision origins
     bake = link.mesh_bake_offset if link.needs_mesh_bake else (0.0, 0.0, 0.0)
+    mesh_rpy = getattr(link, "mesh_origin_rpy", (0.0, 0.0, 0.0))
     
     lines.append(f'{pad}<link name="{name}">')
     
     # Inertial — CoM is relative to component origin, shift by bake offset
     mass = max(link.mass_kg, MIN_MASS)
-    com = (
-        link.com_link_local[0] + bake[0],
-        link.com_link_local[1] + bake[1],
-        link.com_link_local[2] + bake[2],
-    )
+    if getattr(link, "inertial_origin_xyz", None) is not None:
+        com = link.inertial_origin_xyz
+    else:
+        com = (
+            link.com_link_local[0] + bake[0],
+            link.com_link_local[1] + bake[1],
+            link.com_link_local[2] + bake[2],
+        )
     inertia = link.inertia_at_com
     ixx = max(abs(inertia.ixx), MIN_INERTIA)
     iyy = max(abs(inertia.iyy), MIN_INERTIA)
@@ -367,7 +372,8 @@ def _generate_link_xml(
     # silent failure in many parsers).
     if link.has_visual_mesh and link.mesh_visual:
         lines.append(f'{pad}  <visual>')
-        lines.append(f'{pad}    <origin xyz="{bake[0]:.6f} {bake[1]:.6f} {bake[2]:.6f}" rpy="0 0 0"/>')
+        lines.append(f'{pad}    <origin xyz="{bake[0]:.6f} {bake[1]:.6f} {bake[2]:.6f}" '
+                     f'rpy="{mesh_rpy[0]:.6f} {mesh_rpy[1]:.6f} {mesh_rpy[2]:.6f}"/>')
         lines.append(f'{pad}    <geometry>')
         lines.append(f'{pad}      <mesh filename="package://{config.package_name}/{link.mesh_visual}" scale="{visual_scale}"/>')
         lines.append(f'{pad}    </geometry>')
@@ -391,8 +397,10 @@ def _generate_link_xml(
         # Collision STL (explicit from Fusion, or generated automatically).
         # STL is always in centimeters (rescaled at export); scale="0.01".
         coll_scale = _scale_for_mesh(collision.mesh_path)
+        coll_rpy = getattr(collision, "origin_rpy", (0.0, 0.0, 0.0))
         lines.append(f'{pad}  <collision>')
-        lines.append(f'{pad}    <origin xyz="{coll_origin[0]:.6f} {coll_origin[1]:.6f} {coll_origin[2]:.6f}" rpy="0 0 0"/>')
+        lines.append(f'{pad}    <origin xyz="{coll_origin[0]:.6f} {coll_origin[1]:.6f} {coll_origin[2]:.6f}" '
+                     f'rpy="{coll_rpy[0]:.6f} {coll_rpy[1]:.6f} {coll_rpy[2]:.6f}"/>')
         lines.append(f'{pad}    <geometry>')
         lines.append(f'{pad}      <mesh filename="package://{config.package_name}/{collision.mesh_path}" scale="{coll_scale}"/>')
         lines.append(f'{pad}    </geometry>')
@@ -401,7 +409,8 @@ def _generate_link_xml(
         # Fallback: use visual mesh as collision (only when the visual
         # actually exists — otherwise we'd reference a missing file).
         lines.append(f'{pad}  <collision>')
-        lines.append(f'{pad}    <origin xyz="{bake[0]:.6f} {bake[1]:.6f} {bake[2]:.6f}" rpy="0 0 0"/>')
+        lines.append(f'{pad}    <origin xyz="{bake[0]:.6f} {bake[1]:.6f} {bake[2]:.6f}" '
+                     f'rpy="{mesh_rpy[0]:.6f} {mesh_rpy[1]:.6f} {mesh_rpy[2]:.6f}"/>')
         lines.append(f'{pad}    <geometry>')
         lines.append(f'{pad}      <mesh filename="package://{config.package_name}/{link.mesh_visual}" scale="{visual_scale}"/>')
         lines.append(f'{pad}    </geometry>')
@@ -543,6 +552,20 @@ def _order_links(
 def _xml_safe(s: str) -> str:
     """Make string safe for XML attribute."""
     return s.replace('&', '&amp;').replace('"', '&quot;').replace('<', '&lt;').replace('>', '&gt;')
+
+
+def _xacro_macro_name(assembly_name: str) -> str:
+    """Return an XML-NCName-safe xacro macro/call name.
+
+    Fusion assembly names often begin with a part number (for example
+    ``10034_Servo_Pack``).  That is valid as a filename but invalid as the
+    local part of ``<xacro:...>``.  Prefix only when needed so ordinary macro
+    names remain stable.
+    """
+    name = re.sub(r"[^A-Za-z0-9_.-]", "_", assembly_name or "assembly")
+    if not re.match(r"[A-Za-z_]", name):
+        name = f"assembly_{name}"
+    return name
 
 
 def _scale_for_mesh(mesh_path: str) -> str:

--- a/docs/CUSTOMIZING.md
+++ b/docs/CUSTOMIZING.md
@@ -41,6 +41,40 @@ A `!dummy_` assembly (for example `!dummy_camera`, exported as the
 
 New joints are added in Fusion 360 by creating joints between components. The exporter automatically detects joint type (revolute, prismatic, fixed) from the Fusion joint's motion type.
 
+## Adjusting Frames After Export
+
+With `[frames].convention = "ros"` (the default), the root frame follows the
+Fusion design world with `X` forward and `Z` up, and revolute or continuous
+joints use the child link's local `+Z` axis. The exporter compensates visual,
+collision, joint, center-of-mass, and inertia transforms, so this coordinate
+change does not move the mechanism or alter mesh vertices.
+
+A verbose export writes `config/frame_overrides.csv`. Its supported rules are:
+
+- `auto`: apply the default convention
+- `keep`: retain the extracted link orientation
+- `world_rpy`: give a non-root link an absolute design-world orientation from
+  `post_roll_deg`, `post_pitch_deg`, and `post_yaw_deg`
+
+After editing the CSV, regenerate the frame-dependent files without opening
+Fusion or exporting meshes again:
+
+```powershell
+python tools/reframe.py <path-to-description-package>
+```
+
+The command uses the matching `debug/frame_model.json` cache. For an older
+package that has `debug/snapshot.json` but no frame cache, bootstrap once from
+the snapshot and the meshes already in the package:
+
+```powershell
+python tools/reframe.py <path-to-description-package> --snapshot <path-to-debug/snapshot.json>
+```
+
+These overrides are intentionally orientation-only. To move a link origin or
+joint axis position, add a correctly placed `!frame_*` helper in Fusion and
+export again.
+
 ## Collision Strategy
 
 During export you usually choose the collision method through a two-step

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -136,6 +136,13 @@ collision_method = "primitive"
 # Mesh resolution from Fusion: "low", "medium", "high".
 mesh_refinement = "medium"
 
+[frames]
+# "ros" keeps the Fusion design-world root X-forward/Z-up and expresses
+# revolute/continuous motion as child-local +Z. "fusion" keeps extracted
+# orientations unless a CSV row overrides them.
+convention = "ros"
+overrides_file = "frame_overrides.csv"
+
 [ros2_control]
 # Generic mock hardware lets controller_manager start without custom drivers.
 # Replace with your real plugin when wiring real hardware.
@@ -181,6 +188,8 @@ For the special-prefix conventions (`!frame_*`, `!collision_*`, `!dummy_*`, `!pa
     launch/display.launch.py          # RViz + ros2_control bringup
     config/joint_state.yaml
     config/ros2_controllers.yaml
+    config/frame_overrides.csv        # editable post-export orientations
+    config/FRAME_OVERRIDES.md         # CSV rule reference
     rviz/display.rviz
     robot_data.yaml                   # supplementary data beyond URDF
     docs/transforms.md                # KaTeX joint transforms
@@ -188,14 +197,26 @@ For the special-prefix conventions (`!frame_*`, `!collision_*`, `!dummy_*`, `!pa
     README.md                         # auto-generated package README
     package.xml
     CMakeLists.txt
-    debug/                            # only when include_debug = true
-      snapshot.json
-      extraction_report.md
-      validation.md
-      export_log.md
+  debug/                              # sibling; include_debug = true
+    snapshot.json
+    frame_model.json                  # canonical offline reframe cache
+    extraction_report.md
+    validation.md
+    export_log.md
 ```
 
 Optional files depend on `xacro_export.toml` feature toggles and `[output].verbosity`.
+
+The frame CSV is editable. Reapply it from the repository root
+without rerunning Fusion extraction or mesh export:
+
+```powershell
+python tools/reframe.py <output_dir>/<robot>_description
+```
+
+The package's visual and physical placement stays unchanged; only its link
+coordinate orientations are rebased. Use a `!frame_*` helper and export again
+when an origin or joint-axis position must move.
 
 ## Build and launch
 

--- a/docs/LIMITATIONS.md
+++ b/docs/LIMITATIONS.md
@@ -16,8 +16,18 @@ If a component origin is wrong but the geometry is otherwise good, add a
 merged link frame and does not export as geometry. This is the preferred fix
 for base frames, wheel centers, sensor frames, mount frames, and tool frames.
 
-If many joints were created around the wrong world orientation, rebuilding the
-small assembly can be faster and safer than trying to patch every joint.
+Orientation cleanup no longer requires rebuilding the assembly. The default
+post-export ROS convention keeps the Fusion design-world root `X` forward and
+`Z` up and rebases revolute/continuous child frames to local `+Z`. A verbose
+export writes `config/frame_overrides.csv`; `auto`, `keep`, and non-root
+`world_rpy` rules can be reapplied from `debug/frame_model.json` without
+reopening Fusion or regenerating meshes.
+
+Frame overrides are orientation-only. They cannot move a link origin or a
+joint's physical axis position while preserving revolute motion. For those
+changes, place a `!frame_*` helper at the intended position and export again.
+An arbitrary root `world_rpy` also requires a wrapper link, so the root uses
+the selected automatic convention instead.
 
 ## Rigid Groups
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,87 @@
+# Testing
+
+The test suite runs outside Fusion 360 using pure Python. No Fusion API is
+required for the normal regression suite.
+
+## CI-Equivalent Local Check
+
+From the repository root, run both commands before opening a pull request:
+
+```powershell
+python run_tests.py
+python scripts/validate_examples.py examples/
+```
+
+GitHub Actions runs the same checks on Python 3.10, 3.11, and 3.12.
+
+## Test Suites
+
+`run_tests.py` executes these suites in order:
+
+- `test_core`: data types, naming, unit conversions, serialization, and math
+- `test_robot_model`: hierarchy, joint resolution, root detection, rigid
+  groups, kinematic topology, and subassembly-container endpoints
+- `test_frame_rebaser`: ROS frame conventions, CSV overrides, mesh/collision/
+  inertia invariance, and cached offline regeneration
+- `test_export_pipeline`: URDF/xacro generation, collision files, package
+  layout, rigid-group anchor correction, frame-only links, and validation
+
+Run one suite from the directory containing the checkout:
+
+```powershell
+python -m fusion2URDF.tests.test_frame_rebaser
+python -m fusion2URDF.tests.test_export_pipeline
+```
+
+The synthetic fixtures make these tests deterministic. If a local
+`debug/snapshot.json` exists, a few additional real-export checks may run;
+tests tied to a different design skip cleanly rather than treating the latest
+snapshot as a stable fixture.
+
+## Example Validation
+
+The committed packages under `examples/` are deliberate, reviewable examples,
+not runtime scratch. The validator checks:
+
+- XML well-formedness for URDF and xacro files
+- resolution of every `package://` mesh reference
+- non-degenerate bounding boxes for generated STL collision meshes
+
+Do not commit normal Fusion output or debug caches. The root `.gitignore`
+keeps `debug/`, Python caches, personal config, coverage output, and test
+scratch out of the repository while leaving the curated examples tracked.
+
+## Offline Tools
+
+From the repository root, validate or visualize a captured Fusion snapshot:
+
+```powershell
+python tools/check.py <path-to-snapshot.json>
+python tools/visualize.py <path-to-snapshot.json>
+```
+
+Reapply `config/frame_overrides.csv` without Fusion or mesh export:
+
+```powershell
+python tools/reframe.py <path-to-description-package>
+```
+
+The command normally discovers the sibling `debug/frame_model.json`. For an
+older package that only has a matching extraction snapshot, bootstrap the
+cache once:
+
+```powershell
+python tools/reframe.py <path-to-description-package> --snapshot <path-to-debug/snapshot.json>
+```
+
+The equivalent module form, when run from the directory containing this
+checkout, is `python -m fusion2URDF.tools.reframe ...`.
+
+## Adding Regression Tests
+
+1. Add `test_<description>()` to the most focused suite.
+2. Add it to that module's `run_all()` function.
+3. Prefer a small synthetic snapshot over the mutable local `debug/` export.
+4. Assert physical invariants, not only string output. Frame changes should
+   prove that mesh, collision, inertia, and forward kinematics stay fixed.
+5. Run the full CI-equivalent local check above.

--- a/fusion2URDF.manifest
+++ b/fusion2URDF.manifest
@@ -1,7 +1,7 @@
 {
     "autodeskProduct": "Fusion360",
     "type": "script",
-    "version": "2",
+    "version": "3.1",
     "author": "Adrian Valaker Eikeland",
     "description": {
         "": "fusion2URDF — export the active Fusion 360 assembly to a complete ROS 2 robot_description package: hierarchical xacro, meshes, collision, and ros2_control."

--- a/run_tests.py
+++ b/run_tests.py
@@ -31,6 +31,14 @@ if result.returncode != 0:
     sys.exit(result.returncode)
 
 result = subprocess.run(
+    [sys.executable, '-m', 'fusion2URDF.tests.test_frame_rebaser'],
+    cwd=grandparent
+)
+
+if result.returncode != 0:
+    sys.exit(result.returncode)
+
+result = subprocess.run(
     [sys.executable, '-m', 'fusion2URDF.tests.test_export_pipeline'],
     cwd=grandparent
 )

--- a/tests/test_export_pipeline.py
+++ b/tests/test_export_pipeline.py
@@ -959,6 +959,9 @@ def test_package_structure():
         assert os.path.isfile(os.path.join(pkg_dir, "launch", "display.launch.py"))
         assert os.path.isfile(os.path.join(pkg_dir, "rviz", "display.rviz"))
         assert os.path.isfile(os.path.join(pkg_dir, "config", "joint_state.yaml"))
+        assert os.path.isfile(os.path.join(pkg_dir, "config", "frame_overrides.csv"))
+        assert os.path.isfile(os.path.join(pkg_dir, "config", "FRAME_OVERRIDES.md"))
+        assert os.path.isfile(os.path.join(tmpdir, "debug", "frame_model.json"))
         assert os.path.isdir(os.path.join(pkg_dir, "meshes"))
     
     print("  package_structure: PASS")
@@ -1807,12 +1810,33 @@ def test_real_snapshot_package():
         # Root link first
         assert links[0].attrib['name'] == 'base_link'
         
-        # All links have inertial, visual, collision
+        # Link element contents depend on the source role:
+        # physical links have inertial/visual/collision, accidental empty
+        # links keep minimal inertial only, and explicit !frame_* links are
+        # pure frames with no geometry or inertial.
         for link_elem in links:
             name = link_elem.attrib['name']
-            assert link_elem.find('inertial') is not None, f"Missing inertial: {name}"
-            assert link_elem.find('visual') is not None, f"Missing visual: {name}"
-            assert link_elem.find('collision') is not None, f"Missing collision: {name}"
+            model_link = model.links.get(name)
+            assert model_link is not None, f"URDF link not found in model: {name}"
+
+            inertial = link_elem.find('inertial')
+            visual = link_elem.find('visual')
+            collision = link_elem.find('collision')
+
+            if getattr(model_link, "is_frame_only", False):
+                assert inertial is None, f"Frame-only link should omit inertial: {name}"
+                assert visual is None, f"Frame-only link should omit visual: {name}"
+                assert collision is None, f"Frame-only link should omit collision: {name}"
+                continue
+
+            assert inertial is not None, f"Missing inertial: {name}"
+            if getattr(model_link, "is_empty", False):
+                assert visual is None, f"Empty link should omit visual: {name}"
+                assert collision is None, f"Empty link should omit collision: {name}"
+                continue
+
+            assert visual is not None, f"Missing visual: {name}"
+            assert collision is not None, f"Missing collision: {name}"
         
         # All joints reference existing links
         link_names = {l.attrib['name'] for l in links}
@@ -2215,8 +2239,10 @@ def run_all():
     test_user_config_apply_minimal_verbosity()
     test_user_config_per_key_override_wins()
     test_user_config_accepts_convex_hull_collision_method()
+    test_user_config_accepts_frame_options()
     test_user_config_accepts_ros2_control_options()
     test_user_config_prefers_plugin_local_config_path()
+    test_verbose_package_emits_frame_config_without_rviz_or_control()
     test_minimal_package_skips_optional_dirs()
 
     # Tree viz
@@ -2232,12 +2258,14 @@ def run_all():
     test_urdf_uses_collision_stl_when_visual_missing()
     test_flat_design_emits_assembly_xacro()
     test_safe_identifier_strips_non_ascii_for_urdf()
+    test_numeric_assembly_name_is_xacro_safe()
     test_urdf_material_names_are_ascii_safe()
     test_urdf_joint_names_are_ascii_safe()
     test_acc_prefix_recognised_and_stripped()
     test_acc_rigid_group_uses_visual_mesh_as_collision()
     test_collision_override_prefixes_force_method()
     test_per_member_obj_concat_transforms_and_namespaces()
+    test_merged_obj_anchor_correction_uses_lca_relative_transform()
     test_invalid_fusion_joint_endpoint_is_skipped()
     test_root_side_invalid_joint_endpoint_uses_design_root()
     test_root_component_visual_export_uses_root_bodies_directly()
@@ -2444,6 +2472,26 @@ def test_user_config_accepts_convex_hull_collision_method():
     print("  user_config_accepts_convex_hull_collision_method: PASS")
 
 
+def test_user_config_accepts_frame_options():
+    """TOML selects the frame convention and keeps its CSV inside config/."""
+    from ..core.user_config import apply_to_config
+    from ..core.data_types import ExportConfig
+
+    cfg = ExportConfig()
+    changes = apply_to_config(cfg, {
+        "frames": {
+            "convention": "FUSION",
+            "overrides_file": "nested/custom_frames.csv",
+        },
+    })
+    assert cfg.frame_convention == "fusion"
+    assert cfg.frame_overrides_filename == "custom_frames.csv"
+    assert "frames.convention = fusion" in changes
+    assert "frames.overrides_file = custom_frames.csv" in changes
+
+    print("  user_config_accepts_frame_options: PASS")
+
+
 def test_user_config_accepts_ros2_control_options():
     """TOML can disable ros2_control and tune the generated mock system."""
     from ..core.user_config import apply_to_config
@@ -2578,6 +2626,38 @@ def test_tree_render_marks_multi_parent():
         f"tree should be clean of multi-parent markers after auto-classification:\n{tree}"
     )
     print("  tree_render_marks_multi_parent: PASS")
+
+
+def test_verbose_package_emits_frame_config_without_rviz_or_control():
+    """Verbose frame controls do not depend on unrelated config features."""
+    from ..core.robot_model import build_model
+    from ..core.package_generator import generate_package
+    from ..core.data_types import ExportConfig
+
+    model = build_model(_make_snapshot(), _make_logger())
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg = ExportConfig(
+            package_name="test_robot_description",
+            output_dir=tmp,
+            verbosity="verbose",
+            include_rviz=False,
+            include_ros2_control=False,
+            include_docs=False,
+            include_robot_data_yaml=False,
+            include_readme=False,
+        )
+        pkg = generate_package(model, cfg, _make_logger())
+        assert os.path.isfile(
+            os.path.join(pkg, "config", "frame_overrides.csv")
+        )
+        assert os.path.isfile(
+            os.path.join(pkg, "config", "FRAME_OVERRIDES.md")
+        )
+        with open(os.path.join(pkg, "CMakeLists.txt"), encoding="utf-8") as f:
+            cmake = f.read()
+        assert "config" in cmake.split("install(DIRECTORY", 1)[1].split(")", 1)[0]
+
+    print("  verbose_package_emits_frame_config_without_rviz_or_control: PASS")
 
 
 def test_minimal_package_skips_optional_dirs():
@@ -3037,6 +3117,119 @@ def test_per_member_obj_concat_transforms_and_namespaces():
         assert "0.1 0.2 0.3" in mtl_text
 
     print("  per_member_obj_concat_transforms_and_namespaces: PASS")
+
+
+def test_merged_obj_anchor_correction_uses_lca_relative_transform():
+    """Merged OBJ vertices use the anchor pose relative to the export LCA.
+
+    Using an anchor transform relative to an intermediate parent assembly
+    displaces root-spanning rigid groups when the nested component has an
+    unusual parent-local origin.
+    """
+    from ..core.data_types import FusionOccurrence, FusionSnapshot, Transform3D
+    from ..core.fusion_extractor import (
+        _maybe_apply_anchor_frame_correction, _read_obj_data,
+    )
+    from ..core.robot_model import _mat3_mul, _rotate_vec3_by_mat3
+
+    rz_90 = (0.0, -1.0, 0.0,
+             1.0,  0.0, 0.0,
+             0.0,  0.0, 1.0)
+    rx_90 = (1.0, 0.0,  0.0,
+             0.0, 0.0, -1.0,
+             0.0, 1.0,  0.0)
+    identity = (1.0, 0.0, 0.0,
+                0.0, 1.0, 0.0,
+                0.0, 0.0, 1.0)
+
+    def write_obj(path, vertex, normal):
+        with open(path, "w", encoding="utf-8") as f:
+            f.write(f"v {vertex[0]} {vertex[1]} {vertex[2]}\n")
+            f.write(f"vn {normal[0]} {normal[1]} {normal[2]}\n")
+
+    def assert_vec_close(actual, expected):
+        assert all(abs(a - e) < 1e-6 for a, e in zip(actual, expected)), (
+            f"expected {expected}, got {actual}"
+        )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        # Root LCA: local_transform is deliberately unrelated. Fusion's
+        # root-targeted OBJ must instead be inverted with transform2.
+        root_obj = os.path.join(tmp, "root_lca.obj")
+        anchor_local_vertex = (2.0, 3.0, 4.0)  # OBJ units: cm
+        anchor_local_normal = (1.0, 0.0, 0.0)
+        anchor_world_translation = (0.12, -0.34, 0.56)  # metres
+        rotated_vertex = _rotate_vec3_by_mat3(anchor_local_vertex, rz_90)
+        root_vertex = tuple(
+            rotated_vertex[i] + anchor_world_translation[i] * 100.0
+            for i in range(3)
+        )
+        root_normal = _rotate_vec3_by_mat3(anchor_local_normal, rz_90)
+        write_obj(root_obj, root_vertex, root_normal)
+
+        root_anchor = FusionOccurrence(
+            local_transform=Transform3D(
+                translation=(1.94, -0.06, 0.04), rotation=identity,
+            ),
+            transform2=Transform3D(
+                translation=anchor_world_translation, rotation=rz_90,
+            ),
+        )
+        _maybe_apply_anchor_frame_correction(
+            root_obj, root_anchor, "", FusionSnapshot(), _make_logger(),
+        )
+        corrected = _read_obj_data(root_obj)
+        assert_vec_close(corrected["vertices"][0], anchor_local_vertex)
+        assert_vec_close(corrected["normals"][0], anchor_local_normal)
+
+        # Nested LCA: derive LCA inverse * anchor from the two world poses.
+        nested_obj = os.path.join(tmp, "nested_lca.obj")
+        lca_translation = (1.0, 2.0, 3.0)
+        anchor_in_lca_translation = (0.2, 0.3, 0.4)
+        anchor_world_rotation = _mat3_mul(rz_90, rx_90)
+        anchor_world_offset = _rotate_vec3_by_mat3(
+            anchor_in_lca_translation, rz_90,
+        )
+        nested_anchor_world_translation = tuple(
+            lca_translation[i] + anchor_world_offset[i] for i in range(3)
+        )
+        lca_vertex_rotated = _rotate_vec3_by_mat3(
+            anchor_local_vertex, rx_90,
+        )
+        lca_vertex = tuple(
+            lca_vertex_rotated[i] + anchor_in_lca_translation[i] * 100.0
+            for i in range(3)
+        )
+        lca_normal = _rotate_vec3_by_mat3(anchor_local_normal, rx_90)
+        write_obj(nested_obj, lca_vertex, lca_normal)
+
+        lca_path = "outer:1"
+        snap = FusionSnapshot(occurrences={
+            lca_path: FusionOccurrence(
+                full_path=lca_path,
+                transform2=Transform3D(
+                    translation=lca_translation, rotation=rz_90,
+                ),
+            ),
+        })
+        nested_anchor = FusionOccurrence(
+            parent_path="outer:1+middle:1",
+            local_transform=Transform3D(
+                translation=(9.0, 8.0, 7.0), rotation=identity,
+            ),
+            transform2=Transform3D(
+                translation=nested_anchor_world_translation,
+                rotation=anchor_world_rotation,
+            ),
+        )
+        _maybe_apply_anchor_frame_correction(
+            nested_obj, nested_anchor, lca_path, snap, _make_logger(),
+        )
+        corrected = _read_obj_data(nested_obj)
+        assert_vec_close(corrected["vertices"][0], anchor_local_vertex)
+        assert_vec_close(corrected["normals"][0], anchor_local_normal)
+
+    print("  merged_obj_anchor_correction_uses_lca_relative_transform: PASS")
 
 
 def test_invalid_fusion_joint_endpoint_is_skipped():
@@ -3658,6 +3851,24 @@ def test_safe_identifier_strips_non_ascii_for_urdf():
     assert safe_identifier("aluminum_6061") == "aluminum_6061"
 
     print("  safe_identifier_strips_non_ascii_for_urdf: PASS")
+
+
+def test_numeric_assembly_name_is_xacro_safe():
+    """Part-number assembly names must remain valid XML/xacro tag names."""
+    from ..core.xacro_generator import XACRO_NS, _xacro_macro_name
+
+    assert _xacro_macro_name("turret") == "turret"
+    assert _xacro_macro_name("10034_Servo_Pack") == "assembly_10034_Servo_Pack"
+    assert _xacro_macro_name("10034 Servo Pack") == "assembly_10034_Servo_Pack"
+
+    macro_name = _xacro_macro_name("10034_Servo_Pack")
+    ET.fromstring(
+        f'<robot xmlns:xacro="{XACRO_NS}">'
+        f'<xacro:{macro_name} prefix=""/>'
+        f'</robot>'
+    )
+
+    print("  numeric_assembly_name_is_xacro_safe: PASS")
 
 
 def test_urdf_material_names_are_ascii_safe():

--- a/tests/test_frame_rebaser.py
+++ b/tests/test_frame_rebaser.py
@@ -1,0 +1,406 @@
+"""Regression tests for the offline frame-rebasing layer."""
+
+from __future__ import annotations
+
+import copy
+import csv
+import math
+import os
+import tempfile
+
+from ..core.data_types import (
+    AssemblyInfo,
+    CollisionInfo,
+    ExportConfig,
+    InertiaTensor,
+    JointNode,
+    LinkNode,
+    RobotModel,
+)
+from ..core.frame_rebaser import (
+    IDENTITY_3,
+    apply_frame_rebases,
+    configure_frames,
+    load_frame_cache,
+    mat3_mul,
+    mat3_transpose,
+    mat3_vec,
+    plan_frame_rebases,
+    rpy_to_matrix,
+    save_frame_cache,
+)
+from ..core.robot_model import build_model
+from ..core.snapshot_io import load_snapshot
+from ..core.xacro_generator import generate_urdf
+from ..utils.logger import Logger
+
+
+TOL = 2e-8
+
+
+def _logger():
+    return Logger(timestamps=False, quiet=True)
+
+
+def _assert_vec_close(actual, expected, tol=TOL):
+    assert len(actual) == len(expected)
+    for a, b in zip(actual, expected):
+        assert abs(a - b) <= tol, (actual, expected)
+
+
+def _assert_matrix_close(actual, expected, tol=TOL):
+    _assert_vec_close(tuple(actual), tuple(expected), tol=tol)
+
+
+def _axis_rotation(axis, angle):
+    x, y, z = axis
+    length = math.sqrt(x * x + y * y + z * z)
+    x, y, z = x / length, y / length, z / length
+    c, s, one_c = math.cos(angle), math.sin(angle), 1.0 - math.cos(angle)
+    return (
+        c + x * x * one_c,
+        x * y * one_c - z * s,
+        x * z * one_c + y * s,
+        y * x * one_c + z * s,
+        c + y * y * one_c,
+        y * z * one_c - x * s,
+        z * x * one_c - y * s,
+        z * y * one_c + x * s,
+        c + z * z * one_c,
+    )
+
+
+def _compose(a, b):
+    """Compose two (rotation, translation) rigid transforms."""
+    ra, ta = a
+    rb, tb = b
+    rotated_tb = mat3_vec(ra, tb)
+    return (
+        mat3_mul(ra, rb),
+        (ta[0] + rotated_tb[0], ta[1] + rotated_tb[1], ta[2] + rotated_tb[2]),
+    )
+
+
+def _zero_or_configured_fk(model, root_rotation, joint_positions):
+    poses = {model.root_link: (root_rotation, (0.0, 0.0, 0.0))}
+    remaining = list(model.joints.values())
+    while remaining:
+        progressed = False
+        next_remaining = []
+        for joint in remaining:
+            parent = poses.get(joint.parent_link)
+            if parent is None:
+                next_remaining.append(joint)
+                continue
+            origin = (rpy_to_matrix(tuple(joint.origin_rpy)), tuple(joint.origin_xyz))
+            q = joint_positions.get(joint.name, 0.0)
+            if joint.joint_type in ("revolute", "continuous"):
+                motion = (_axis_rotation(tuple(joint.axis), q), (0.0, 0.0, 0.0))
+            elif joint.joint_type == "prismatic":
+                motion = (
+                    IDENTITY_3,
+                    (joint.axis[0] * q, joint.axis[1] * q, joint.axis[2] * q),
+                )
+            else:
+                motion = (IDENTITY_3, (0.0, 0.0, 0.0))
+            poses[joint.child_link] = _compose(_compose(parent, origin), motion)
+            progressed = True
+        if not progressed:
+            raise AssertionError("Test model is not a connected tree")
+        remaining = next_remaining
+    return poses
+
+
+def _mesh_world_poses(model, root_rotation, joint_positions):
+    link_poses = _zero_or_configured_fk(model, root_rotation, joint_positions)
+    result = {}
+    for name, link in model.links.items():
+        bake = link.mesh_bake_offset if link.needs_mesh_bake else (0.0, 0.0, 0.0)
+        mesh = (rpy_to_matrix(tuple(link.mesh_origin_rpy)), tuple(bake))
+        result[name] = _compose(link_poses[name], mesh)
+    return result
+
+
+def _make_articulated_model():
+    root_world = rpy_to_matrix((math.radians(-90.0), 0.0, math.radians(20.0)))
+    joint_rpy = (math.radians(15.0), math.radians(-25.0), math.radians(35.0))
+    child_world = mat3_mul(root_world, rpy_to_matrix(joint_rpy))
+    sensor_joint_rpy = (0.0, math.radians(12.0), math.radians(-18.0))
+    sensor_world = mat3_mul(child_world, rpy_to_matrix(sensor_joint_rpy))
+    model = RobotModel(name="frame_test", root_link="base_link")
+    model.links = {
+        "base_link": LinkNode(
+            urdf_name="base_link",
+            assembly="frame_assembly",
+            source_world_rotation=root_world,
+            mass_kg=2.0,
+            com_link_local=(0.02, -0.01, 0.04),
+            inertia_at_com=InertiaTensor(
+                ixx=0.11, ixy=0.012, ixz=-0.007,
+                iyy=0.22, iyz=0.009, izz=0.31,
+            ),
+            mesh_visual="meshes/base.dae",
+            mesh_collision="meshes/base_collision.stl",
+            collision=CollisionInfo(
+                source="explicit",
+                mesh_path="meshes/base_collision.stl",
+            ),
+        ),
+        "tilt_link": LinkNode(
+            urdf_name="tilt_link",
+            assembly="frame_assembly",
+            source_world_rotation=child_world,
+            mass_kg=1.0,
+            com_link_local=(0.08, 0.01, -0.03),
+            inertia_at_com=InertiaTensor(
+                ixx=0.04, ixy=-0.003, ixz=0.006,
+                iyy=0.08, iyz=0.002, izz=0.09,
+            ),
+            mesh_visual="meshes/tilt.dae",
+            mesh_collision="meshes/tilt_collision.stl",
+            mesh_bake_offset=(0.03, -0.02, 0.01),
+            needs_mesh_bake=True,
+            collision=CollisionInfo(
+                source="explicit",
+                mesh_path="meshes/tilt_collision.stl",
+            ),
+        ),
+        "sensor_link": LinkNode(
+            urdf_name="sensor_link",
+            assembly="frame_assembly",
+            source_world_rotation=sensor_world,
+            mass_kg=0.1,
+            com_link_local=(0.01, 0.0, 0.0),
+            inertia_at_com=InertiaTensor(ixx=0.001, iyy=0.002, izz=0.003),
+            mesh_visual="meshes/sensor.dae",
+            mesh_collision="meshes/sensor_collision.stl",
+            collision=CollisionInfo(
+                source="explicit",
+                mesh_path="meshes/sensor_collision.stl",
+            ),
+        ),
+    }
+    model.joints = {
+        "tilt_joint": JointNode(
+            name="tilt_joint",
+            joint_type="revolute",
+            parent_link="base_link",
+            child_link="tilt_link",
+            origin_xyz=(0.15, -0.04, 0.09),
+            origin_rpy=joint_rpy,
+            axis=(1.0, 0.0, 0.0),
+        ),
+        "sensor_joint": JointNode(
+            name="sensor_joint",
+            joint_type="fixed",
+            parent_link="tilt_link",
+            child_link="sensor_link",
+            origin_xyz=(0.04, 0.02, -0.01),
+            origin_rpy=sensor_joint_rpy,
+        ),
+    }
+    model.assemblies = {
+        "frame_assembly": AssemblyInfo(
+            name="frame_assembly",
+            links=["base_link", "tilt_link", "sensor_link"],
+            joints=["tilt_joint", "sensor_joint"],
+        )
+    }
+    return model, root_world
+
+
+def test_ros_rebase_preserves_mesh_fk_and_inertia():
+    canonical, old_root_world = _make_articulated_model()
+    rebased = copy.deepcopy(canonical)
+    plan = plan_frame_rebases(rebased, convention="ros", log=_logger())
+
+    _assert_matrix_close(plan["base_link"]["desired_world"], IDENTITY_3)
+    apply_frame_rebases(rebased, plan, log=_logger())
+    _assert_vec_close(rebased.joints["tilt_joint"].axis, (0.0, 0.0, 1.0))
+
+    for q in (0.0, 0.37, -1.1):
+        positions = {"tilt_joint": q}
+        before = _mesh_world_poses(canonical, old_root_world, positions)
+        after = _mesh_world_poses(rebased, IDENTITY_3, positions)
+        for name in canonical.links:
+            _assert_matrix_close(after[name][0], before[name][0])
+            _assert_vec_close(after[name][1], before[name][1])
+
+        # World inertia at the moving link CoM must also be invariant.
+        before_link_r = _zero_or_configured_fk(
+            canonical, old_root_world, positions
+        )["tilt_link"][0]
+        after_link_r = _zero_or_configured_fk(
+            rebased, IDENTITY_3, positions
+        )["tilt_link"][0]
+        before_i = _inertia_matrix(canonical.links["tilt_link"].inertia_at_com)
+        after_i = _inertia_matrix(rebased.links["tilt_link"].inertia_at_com)
+        before_world_i = mat3_mul(
+            mat3_mul(before_link_r, before_i), mat3_transpose(before_link_r)
+        )
+        after_world_i = mat3_mul(
+            mat3_mul(after_link_r, after_i), mat3_transpose(after_link_r)
+        )
+        _assert_matrix_close(after_world_i, before_world_i)
+
+
+def test_csv_override_and_cache_round_trip():
+    model, _ = _make_articulated_model()
+    cfg = ExportConfig(
+        package_name="frame_test_description",
+        frame_convention="ros",
+        include_ros2_control=False,
+        include_docs=False,
+        include_robot_data_yaml=False,
+        include_readme=False,
+        include_rviz=False,
+    )
+    with tempfile.TemporaryDirectory(dir=os.getcwd()) as temp_dir:
+        package_dir = os.path.join(temp_dir, cfg.package_name)
+        cache_path = os.path.join(temp_dir, "debug", "frame_model.json")
+        save_frame_cache(model, cfg, cache_path)
+
+        loaded, loaded_cfg = load_frame_cache(cache_path)
+        plan = configure_frames(loaded, loaded_cfg, package_dir, _logger())
+        csv_path = os.path.join(package_dir, "config", "frame_overrides.csv")
+        assert os.path.isfile(csv_path)
+        assert plan["base_link"]["role"] == "root_x_forward_z_up"
+        assert plan["tilt_link"]["role"] == "revolute_axis_z"
+
+        with open(csv_path, "r", encoding="utf-8", newline="") as handle:
+            rows = list(csv.DictReader(handle))
+        for row in rows:
+            if row["link"] == "sensor_link":
+                row["rule"] = "world_rpy"
+                row["post_roll_deg"] = "10"
+                row["post_pitch_deg"] = "20"
+                row["post_yaw_deg"] = "30"
+        with open(csv_path, "w", encoding="utf-8", newline="") as handle:
+            writer = csv.DictWriter(handle, fieldnames=rows[0].keys(), lineterminator="\n")
+            writer.writeheader()
+            writer.writerows(rows)
+
+        loaded_again, loaded_cfg_again = load_frame_cache(cache_path)
+        custom_plan = configure_frames(
+            loaded_again, loaded_cfg_again, package_dir, _logger()
+        )
+        expected = rpy_to_matrix(tuple(math.radians(v) for v in (10, 20, 30)))
+        _assert_matrix_close(custom_plan["sensor_link"]["desired_world"], expected)
+        # The revolute row remained auto and therefore still becomes +Z.
+        _assert_vec_close(
+            loaded_again.joints["tilt_joint"].axis,
+            (0.0, 0.0, 1.0),
+        )
+
+        xml = generate_urdf(loaded_again, loaded_cfg_again)
+        assert 'mesh filename="package://frame_test_description/meshes/base.dae"' in xml
+        assert '<axis xyz="0.000000 0.000000 1.000000"/>' in xml
+        assert 'rpy="0 0 0"' not in _visual_origin_line(xml, "base_link")
+
+        # Exercise the actual user-facing offline command path from the same
+        # canonical cache. It must rewrite descriptions and leave meshes alone.
+        from ..tools.reframe import reframe_package
+        reframe_package(package_dir, cache_path, log=_logger())
+        generated_urdf = os.path.join(package_dir, "urdf", "frame_test.urdf")
+        assert os.path.isfile(generated_urdf)
+        with open(generated_urdf, "r", encoding="utf-8") as handle:
+            regenerated_xml = handle.read()
+        assert '<axis xyz="0.000000 0.000000 1.000000"/>' in regenerated_xml
+
+
+def test_real_snapshot_axes_and_geometry_if_available():
+    package_root = os.path.dirname(os.path.dirname(__file__))
+    snapshot_path = os.path.join(package_root, "debug", "snapshot.json")
+    if not os.path.isfile(snapshot_path):
+        print("  real_snapshot_frame_rebase: SKIPPED (local snapshot not found)")
+        return
+
+    snapshot = load_snapshot(snapshot_path)
+
+    canonical = build_model(snapshot, _logger())
+    rebased = copy.deepcopy(canonical)
+    plan = plan_frame_rebases(rebased, convention="ros", log=_logger())
+    old_root_world = tuple(
+        canonical.links[canonical.root_link].source_world_rotation or IDENTITY_3
+    )
+    apply_frame_rebases(rebased, plan, log=_logger())
+
+    movable = [
+        joint for joint in rebased.joints.values()
+        if joint.joint_type in ("revolute", "continuous")
+    ]
+    for joint in movable:
+        _assert_vec_close(joint.axis, (0.0, 0.0, 1.0), tol=1e-7)
+
+    samples = ({}, {
+        joint.name: (0.37 if index % 2 == 0 else -0.28)
+        for index, joint in enumerate(movable)
+    })
+    for positions in samples:
+        before = _mesh_world_poses(canonical, old_root_world, positions)
+        after = _mesh_world_poses(rebased, IDENTITY_3, positions)
+        for name in canonical.links:
+            _assert_matrix_close(after[name][0], before[name][0], tol=5e-8)
+            _assert_vec_close(after[name][1], before[name][1], tol=5e-8)
+
+    # Legacy-export bootstrap: snapshot + existing mesh files are sufficient
+    # to create frame_model.json and regenerate descriptions without Fusion.
+    from ..tools.reframe import reframe_package
+    with tempfile.TemporaryDirectory(dir=os.getcwd()) as temp_dir:
+        package_dir = os.path.join(temp_dir, f"{canonical.name}_description")
+        for link in canonical.links.values():
+            cached_paths = []
+            if link.mesh_visual:
+                cached_paths.append(os.path.splitext(link.mesh_visual)[0] + ".dae")
+            if link.mesh_collision:
+                cached_paths.append(link.mesh_collision)
+            for relative in cached_paths:
+                if not relative:
+                    continue
+                absolute = os.path.join(package_dir, relative)
+                os.makedirs(os.path.dirname(absolute), exist_ok=True)
+                with open(absolute, "wb") as handle:
+                    handle.write(b"cached-mesh-placeholder")
+        reframe_package(
+            package_dir,
+            log=_logger(),
+            snapshot_path=snapshot_path,
+        )
+        cache = os.path.join(package_dir, "debug", "frame_model.json")
+        urdf = os.path.join(package_dir, "urdf", f"{canonical.name}.urdf")
+        assert os.path.isfile(cache)
+        with open(urdf, "r", encoding="utf-8") as handle:
+            regenerated = handle.read()
+        assert regenerated.count(
+            '<axis xyz="0.000000 0.000000 1.000000"/>'
+        ) >= len(movable)
+    print("  real_snapshot_frame_rebase: PASS")
+
+
+def _inertia_matrix(inertia):
+    return (
+        inertia.ixx, inertia.ixy, inertia.ixz,
+        inertia.ixy, inertia.iyy, inertia.iyz,
+        inertia.ixz, inertia.iyz, inertia.izz,
+    )
+
+
+def _visual_origin_line(xml, link_name):
+    marker = f'<link name="{link_name}">'
+    section = xml.split(marker, 1)[1].split("</link>", 1)[0]
+    visual = section.split("<visual>", 1)[1].split("</visual>", 1)[0]
+    return next(line for line in visual.splitlines() if "<origin " in line)
+
+
+def main():
+    print("Running frame rebaser tests...")
+    test_ros_rebase_preserves_mesh_fk_and_inertia()
+    print("  ros_rebase_preserves_mesh_fk_and_inertia: PASS")
+    test_csv_override_and_cache_round_trip()
+    print("  csv_override_and_cache_round_trip: PASS")
+    test_real_snapshot_axes_and_geometry_if_available()
+    print("All frame rebaser tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_robot_model.py
+++ b/tests/test_robot_model.py
@@ -1379,6 +1379,139 @@ def test_auto_rigid_island_collapses_nested_subassemblies_without_joints():
     print("  auto_rigid_island_collapses_nested_subassemblies_without_joints: PASS")
 
 
+def test_subassembly_joint_endpoint_resolves_to_internal_root_link():
+    """A joint to a subassembly container should attach to its root link.
+
+    This matches Fusion as-built joints authored between top-level
+    subassemblies, where the URDF tree still needs real link endpoints.
+    """
+    from ..core.data_types import (
+        FusionSnapshot,
+        FusionOccurrence,
+        FusionJoint,
+        InertiaTensor,
+        RigidGroupInfo,
+        Transform3D,
+    )
+    from ..core.robot_model import build_model
+
+    snap = FusionSnapshot(
+        design_name="lonewolf_primitive v1",
+        design_name_clean="lonewolf_primitive",
+    )
+
+    def make_occ(
+        path, clean, segs, *, is_sub=False, mass=0.0, bodies=0,
+        pos=(0.0, 0.0, 0.0), is_frame=False, bbox=0.1,
+    ):
+        half = bbox / 2.0
+        return FusionOccurrence(
+            full_path=path,
+            component_name=clean,
+            clean_name=clean,
+            path_segments=list(segs),
+            depth=len(segs) - 1,
+            is_subassembly=is_sub,
+            is_frame_only=is_frame,
+            child_count=1 if is_sub else 0,
+            global_position=pos,
+            local_transform=Transform3D(translation=pos),
+            transform2=Transform3D(translation=pos),
+            mass_kg=mass,
+            body_count=bodies,
+            com_component_local=(0.0, 0.0, 0.0),
+            com_global=pos,
+            inertia_at_origin=InertiaTensor(ixx=0.01, iyy=0.01, izz=0.01),
+            inertia_at_com=InertiaTensor(ixx=0.01, iyy=0.01, izz=0.01),
+            bbox_min=(-half, -half, -half),
+            bbox_max=(half, half, half),
+            bbox_size=(bbox, bbox, bbox),
+            volume_m3=bbox ** 3,
+            area_m2=6 * bbox * bbox,
+        )
+
+    panther = "dummy_panther v14:1"
+    body = f"{panther}+body_link v5:1"
+    wheel = f"{panther}+rl_wheel_link v5:1"
+    rail_asm = "rail_mount_plate v10:1"
+    rail_frame = f"{rail_asm}+!frame_rail_mount_plate_link v1:1"
+    rail_plate = f"{rail_asm}+rail_mount_link v11:1"
+
+    snap.occurrences = {
+        panther: make_occ(panther, "dummy_panther", ["dummy_panther"], is_sub=True),
+        body: make_occ(body, "body_link", ["dummy_panther", "body_link"],
+                       mass=10.0, bodies=1),
+        wheel: make_occ(wheel, "rl_wheel_link", ["dummy_panther", "rl_wheel_link"],
+                        mass=1.0, bodies=1, pos=(-0.2, 0.25, 0.0)),
+        rail_asm: make_occ(rail_asm, "rail_mount_plate", ["rail_mount_plate"],
+                           is_sub=True, pos=(0.0, 0.0, 0.177)),
+        rail_frame: make_occ(
+            rail_frame, "rail_mount_plate_link",
+            ["rail_mount_plate", "rail_mount_plate_link"],
+            pos=(0.0, 0.0, 0.177), is_frame=True,
+        ),
+        rail_plate: make_occ(
+            rail_plate, "rail_mount_link", ["rail_mount_plate", "rail_mount_link"],
+            mass=2.0, bodies=1, pos=(0.0, 0.0, 0.177), bbox=0.4,
+        ),
+    }
+
+    snap.rigid_groups.append(RigidGroupInfo(
+        name="rail_mount_plate_link",
+        occurrence_paths=[rail_frame, rail_plate],
+        member_clean_names=["rail_mount_plate_link", "rail_mount_link"],
+    ))
+    snap.joints = {
+        "rl_wheel": FusionJoint(
+            name="rl_wheel",
+            joint_source="as_built",
+            defining_component="dummy_panther",
+            motion_type="revolute",
+            occurrence_one_path="rl_wheel_link v5:1",
+            occurrence_one_clean="rl_wheel_link",
+            occurrence_two_path="body_link v5:1",
+            occurrence_two_clean="body_link",
+            origin_global_m=(-0.2, 0.25, 0.0),
+            origin_source="geometry.origin",
+            axis_vector=(0.0, 1.0, 0.0),
+        ),
+        "body_to_rail_mount_joint": FusionJoint(
+            name="body_to_rail_mount_joint",
+            joint_source="as_built",
+            defining_component="lonewolf_primitive",
+            motion_type="rigid",
+            occurrence_one_path=rail_asm,
+            occurrence_one_clean="rail_mount_plate",
+            occurrence_two_path=panther,
+            occurrence_two_clean="dummy_panther",
+            origin_global_m=(0.0, 0.0, 0.177),
+            origin_source="occ_one_global",
+            axis_vector=(0.0, 0.0, 1.0),
+        ),
+    }
+
+    model = build_model(snap, _make_logger())
+
+    assert not model.errors, f"unexpected errors: {model.errors}"
+    assert set(model.links) == {"base_link", "rl_wheel_link", "rail_mount_plate_link"}
+    rail = model.links["rail_mount_plate_link"]
+    assert rail.is_merged
+    assert rail.mass_kg == 2.0
+    assert rail_frame in rail.merged_member_paths
+    assert rail_plate in rail.merged_member_paths
+    assert not any("Dropped unreferenced" in w for w in model.warnings)
+    assert not any("could not resolve" in w for w in model.warnings)
+
+    joint = model.joints["body_to_rail_mount_joint"]
+    assert joint.parent_link == "base_link"
+    assert joint.child_link == "rail_mount_plate_link"
+    assert joint.joint_type == "fixed"
+    assert joint.is_mount
+    assert joint.origin_xyz == (0.0, 0.0, 0.177)
+
+    print("  subassembly_joint_endpoint_resolves_to_internal_root_link: PASS")
+
+
 def test_auto_rigid_island_preserves_articulated_subassembly():
     """A subassembly with an internal joint must remain articulated."""
     from ..core.data_types import (
@@ -2320,6 +2453,50 @@ def test_passive_joint_propagates_flag():
     print("  passive_joint_propagates_flag: PASS")
 
 
+def test_jointless_single_link_exports_as_root():
+    """A design with no joints (e.g. a standalone camera body) must
+    export as a single root link instead of crashing in _detect_root."""
+    from ..core.robot_model import build_model
+
+    snap = _make_snapshot({
+        "design_name": "camera v1",
+        "design_name_clean": "camera",
+        "root_component_name": "camera",
+        "occurrences": {
+            "camera v1:1": {
+                "full_path": "camera v1:1",
+                "component_name": "camera v1",
+                "clean_name": "camera",
+                "path_segments": ["camera"],
+                "depth": 0,
+                "is_subassembly": False,
+                "global_position": [0.0, 0.0, 0.0],
+                "local_transform": {"translation": [0, 0, 0], "rotation": [[1,0,0],[0,1,0],[0,0,1]]},
+                "assembly_context_depth": 0,
+                "mass_kg": 0.1, "body_count": 1, "bodies": [],
+                "com_component_local": [0, 0, 0], "com_global": [0, 0, 0],
+                "inertia_at_origin": {"ixx":0.001,"iyy":0.001,"izz":0.001,"ixy":0,"ixz":0,"iyz":0},
+                "inertia_at_com": {"ixx":0.001,"iyy":0.001,"izz":0.001,"ixy":0,"ixz":0,"iyz":0},
+                "bbox_size": [0.03, 0.03, 0.03], "volume_m3": 1e-5, "area_m2": 0.005,
+                "material_name": "", "appearance_name": "", "appearance_color_rgb": None,
+            },
+        },
+        "joints": {},
+    })
+
+    model = build_model(snap, _make_logger())
+
+    assert len(model.joints) == 0, f"Expected no joints, got {list(model.joints)}"
+    assert len(model.links) == 1, f"Expected 1 link, got {list(model.links)}"
+    assert model.root_link, "root_link must be set for a jointless export"
+    assert model.root_link in model.links
+    assert len(model.errors) == 0, f"Unexpected errors: {model.errors}"
+    assert any("No joints found" in w for w in model.warnings), \
+        f"Expected a 'no joints' warning, got: {model.warnings}"
+
+    print("  jointless_single_link_exports_as_root: PASS")
+
+
 # ──────────────────────────────────────────────
 # Runner
 # ──────────────────────────────────────────────
@@ -2353,8 +2530,10 @@ def run_all():
     test_rigid_group_merge_collision_member_excluded_from_anchor_choice()
     test_rigid_group_body_owning_subassembly_with_design_root_joints()
     test_auto_rigid_island_collapses_nested_subassemblies_without_joints()
+    test_subassembly_joint_endpoint_resolves_to_internal_root_link()
     test_auto_rigid_island_preserves_articulated_subassembly()
     test_orphan_link_is_error()
+    test_jointless_single_link_exports_as_root()
     test_unreferenced_empty_occurrence_is_dropped()
     test_frame_only_child_joint_forced_fixed()
     test_real_snapshot()

--- a/tools/check.py
+++ b/tools/check.py
@@ -17,7 +17,6 @@ No external dependencies.
 Author: Adrian Valaker Eikeland
 """
 
-import json
 import os
 import sys
 from datetime import datetime
@@ -28,110 +27,9 @@ _parent = os.path.dirname(_pkg_root)
 if _parent not in sys.path:
     sys.path.insert(0, _parent)
 
-from fusion2URDF.core.data_types import (
-    FusionSnapshot, FusionOccurrence, FusionJoint,
-    InertiaTensor, Transform3D, RigidGroupInfo,
-)
+from fusion2URDF.core.snapshot_io import load_snapshot
 from fusion2URDF.core.robot_model import build_model
 from fusion2URDF.utils.logger import Logger
-
-
-# ──────────────────────────────────────────────
-# Snapshot loader (JSON dict → dataclass)
-# ──────────────────────────────────────────────
-
-def load_snapshot(path: str) -> FusionSnapshot:
-    """Load a FusionSnapshot from a JSON file."""
-    with open(path) as f:
-        data = json.load(f)
-    return _snapshot_from_dict(data)
-
-
-def _snapshot_from_dict(data: dict) -> FusionSnapshot:
-    """Reconstruct FusionSnapshot dataclass tree from JSON dict."""
-    snap = FusionSnapshot(
-        design_name=data.get('design_name', ''),
-        design_name_clean=data.get('design_name_clean', ''),
-        root_component_name=data.get('root_component_name', ''),
-        export_timestamp=data.get('export_timestamp', ''),
-        total_occurrences=data.get('total_occurrences', 0),
-        total_subassemblies=data.get('total_subassemblies', 0),
-        total_leaf_components=data.get('total_leaf_components', 0),
-        total_joints=data.get('total_joints', 0),
-        total_regular_joints=data.get('total_regular_joints', 0),
-        total_as_built_joints=data.get('total_as_built_joints', 0),
-        max_nesting_depth=data.get('max_nesting_depth', 0),
-    )
-
-    for path, od in data.get('occurrences', {}).items():
-        t_data = od.get('local_transform', {})
-        t_trans = t_data.get('translation', [0, 0, 0])
-        t_rot = t_data.get('rotation', [1, 0, 0, 0, 1, 0, 0, 0, 1])
-        if t_rot and isinstance(t_rot[0], list):
-            t_rot = tuple(v for row in t_rot for v in row)
-        else:
-            t_rot = tuple(t_rot) if t_rot else (1, 0, 0, 0, 1, 0, 0, 0, 1)
-
-        i_com = od.get('inertia_at_com', {})
-        i_orig = od.get('inertia_at_origin', {})
-
-        occ = FusionOccurrence(
-            full_path=od.get('full_path', path),
-            component_name=od.get('component_name', ''),
-            clean_name=od.get('clean_name', ''),
-            path_segments=od.get('path_segments', []),
-            depth=od.get('depth', 0),
-            is_subassembly=od.get('is_subassembly', False),
-            global_position=tuple(od.get('global_position', [0, 0, 0])),
-            local_transform=Transform3D(translation=tuple(t_trans), rotation=t_rot),
-            assembly_context_depth=od.get('assembly_context_depth', 0),
-            mass_kg=od.get('mass_kg', 0),
-            body_count=od.get('body_count', 0),
-            com_component_local=tuple(od.get('com_component_local', [0, 0, 0])),
-            com_global=tuple(od.get('com_global', [0, 0, 0])),
-            inertia_at_origin=InertiaTensor(**i_orig) if i_orig else InertiaTensor(),
-            inertia_at_com=InertiaTensor(**i_com) if i_com else InertiaTensor(),
-            bbox_size=tuple(od.get('bbox_size', [0, 0, 0])),
-            volume_m3=od.get('volume_m3', 0),
-            area_m2=od.get('area_m2', 0),
-            material_name=od.get('material_name', ''),
-            appearance_name=od.get('appearance_name', ''),
-            appearance_color_rgb=tuple(od['appearance_color_rgb']) if od.get('appearance_color_rgb') else None,
-        )
-        snap.occurrences[path] = occ
-
-    for jname, jd in data.get('joints', {}).items():
-        joint = FusionJoint(
-            name=jd.get('name', jname),
-            joint_source=jd.get('joint_source', ''),
-            defining_component=jd.get('defining_component', ''),
-            motion_type=jd.get('motion_type', 'rigid'),
-            occurrence_one_path=jd.get('occurrence_one_path', ''),
-            occurrence_one_clean=jd.get('occurrence_one_clean', ''),
-            occurrence_two_path=jd.get('occurrence_two_path', ''),
-            occurrence_two_clean=jd.get('occurrence_two_clean', ''),
-            origin_global_m=tuple(jd.get('origin_global_m', [0, 0, 0])),
-            origin_source=jd.get('origin_source', ''),
-            axis_vector=tuple(jd.get('axis_vector', [0, 0, 1])),
-            has_rotation_limits=jd.get('has_rotation_limits', False),
-            rotation_min=jd.get('rotation_min'),
-            rotation_max=jd.get('rotation_max'),
-            has_slide_limits=jd.get('has_slide_limits', False),
-            slide_min_m=jd.get('slide_min_m'),
-            slide_max_m=jd.get('slide_max_m'),
-        )
-        snap.joints[jname] = joint
-
-    for rg_data in data.get('rigid_groups', []):
-        snap.rigid_groups.append(RigidGroupInfo(
-            name=rg_data.get('name', ''),
-            occurrence_paths=rg_data.get('occurrence_paths', []),
-            member_clean_names=rg_data.get('member_clean_names', []),
-            collision_member=rg_data.get('collision_member'),
-            collision_path=rg_data.get('collision_path'),
-        ))
-
-    return snap
 
 
 # ──────────────────────────────────────────────

--- a/tools/reframe.py
+++ b/tools/reframe.py
@@ -1,0 +1,223 @@
+"""Regenerate frame-dependent robot-description files without Fusion.
+
+Usage from the repository root::
+
+    python tools/reframe.py path/to/my_robot_description
+
+Or, from the directory containing the checkout::
+
+    python -m fusion2URDF.tools.reframe path/to/my_robot_description
+
+The command reads ``debug/frame_model.json`` (normally beside the package),
+then applies ``<package>/config/frame_overrides.csv`` and rewrites Xacro,
+flat URDF, robot_data.yaml, transform docs, and frame-dependent configs.
+Meshes and collision STL files are not touched.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+# Support both ``python tools/reframe.py`` and ``python -m ...tools.reframe``.
+_pkg_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_parent = os.path.dirname(_pkg_root)
+if _parent not in sys.path:
+    sys.path.insert(0, _parent)
+
+from fusion2URDF.core.frame_rebaser import (  # noqa: E402
+    FRAME_CACHE_FILENAME,
+    configure_frames,
+    load_frame_cache,
+    save_frame_cache,
+)
+from fusion2URDF.core.data_types import (  # noqa: E402
+    CollisionInfo,
+    ExportConfig,
+)
+from fusion2URDF.core.package_generator import (  # noqa: E402
+    generate_validation_report,
+    regenerate_frame_outputs,
+)
+from fusion2URDF.core.robot_model import build_model  # noqa: E402
+from fusion2URDF.core.snapshot_io import load_snapshot  # noqa: E402
+from fusion2URDF.utils.logger import Logger  # noqa: E402
+
+
+def find_frame_cache(package_dir: str, explicit: str = "") -> str:
+    """Find the canonical cache for a generated description package."""
+    candidates = []
+    if explicit:
+        candidates.append(os.path.abspath(explicit))
+    candidates.extend((
+        os.path.join(package_dir, "debug", FRAME_CACHE_FILENAME),
+        os.path.join(os.path.dirname(package_dir), "debug", FRAME_CACHE_FILENAME),
+    ))
+    for candidate in candidates:
+        if os.path.isfile(candidate):
+            return candidate
+    tried = "\n  ".join(candidates)
+    raise FileNotFoundError(
+        f"Could not find {FRAME_CACHE_FILENAME}. Tried:\n  {tried}\n"
+        "Run one Fusion export with include_debug=true to create the cache."
+    )
+
+
+def bootstrap_frame_cache(
+    package_dir: str,
+    snapshot_path: str,
+    cache_path: str = "",
+    log=None,
+) -> str:
+    """Create the first canonical cache from an existing legacy export.
+
+    This reuses ``snapshot.json`` plus the meshes already present in the
+    package.  It does not call Fusion and does not regenerate mesh files.
+    """
+    package_dir = os.path.abspath(package_dir)
+    snapshot_path = os.path.abspath(snapshot_path)
+    if not os.path.isfile(snapshot_path):
+        raise FileNotFoundError(f"Snapshot not found: {snapshot_path}")
+    log = log or Logger(timestamps=False, quiet=False)
+    snapshot = load_snapshot(snapshot_path)
+    model = build_model(snapshot, log)
+
+    expected_package = f"{model.name}_description"
+    package_name = os.path.basename(os.path.normpath(package_dir))
+    if package_name != expected_package:
+        raise ValueError(
+            f"Snapshot design '{model.name}' expects package "
+            f"'{expected_package}', not '{package_name}'"
+        )
+
+    config = ExportConfig(
+        package_name=package_name,
+        output_dir=os.path.dirname(package_dir),
+        include_debug=True,
+        include_docs=os.path.isdir(os.path.join(package_dir, "docs")),
+        include_robot_data_yaml=os.path.isfile(
+            os.path.join(package_dir, "robot_data.yaml")
+        ),
+        include_readme=os.path.isfile(os.path.join(package_dir, "README.md")),
+        include_rviz=os.path.isdir(os.path.join(package_dir, "rviz")),
+        include_launch=os.path.isdir(os.path.join(package_dir, "launch")),
+        include_screenshot=os.path.isfile(
+            os.path.join(package_dir, "images", "robot.png")
+        ),
+        include_ros2_control=False,
+    )
+
+    formats = set()
+    for link in model.links.values():
+        # Mesh paths are deterministic from Phase 2; select the format that is
+        # actually on disk in the already-generated package.
+        stem = os.path.splitext(link.mesh_visual)[0]
+        found_visual = ""
+        for extension in (".dae", ".obj"):
+            candidate = stem + extension
+            if os.path.isfile(os.path.join(package_dir, candidate)):
+                found_visual = candidate
+                formats.add(extension[1:])
+                break
+        link.mesh_visual = found_visual or link.mesh_visual
+        link.has_visual_mesh = bool(found_visual)
+
+        collision_path = link.mesh_collision
+        if collision_path and os.path.isfile(os.path.join(package_dir, collision_path)):
+            link.collision = CollisionInfo(
+                source="cached_existing",
+                mesh_path=collision_path,
+            )
+        elif found_visual:
+            link.collision = CollisionInfo(
+                source="visual_reuse",
+                mesh_path=found_visual,
+            )
+        else:
+            link.collision = None
+
+    if len(formats) == 1:
+        config.visual_format = next(iter(formats))
+
+    if not cache_path:
+        cache_path = os.path.join(package_dir, "debug", FRAME_CACHE_FILENAME)
+    cache_path = os.path.abspath(cache_path)
+    save_frame_cache(model, config, cache_path)
+    log(f"  Bootstrapped canonical cache: {cache_path}")
+    return cache_path
+
+
+def reframe_package(
+    package_dir: str,
+    cache_path: str = "",
+    log=None,
+    snapshot_path: str = "",
+) -> str:
+    """Apply CSV overrides and rewrite descriptions; return cache path used."""
+    package_dir = os.path.abspath(package_dir)
+    if not os.path.isdir(package_dir):
+        raise FileNotFoundError(f"Package directory not found: {package_dir}")
+
+    if snapshot_path:
+        # Supplying a snapshot is an explicit request to (re)build the cache;
+        # useful for packages exported before frame_model.json existed.
+        cache_path = bootstrap_frame_cache(
+            package_dir,
+            snapshot_path,
+            cache_path=cache_path,
+            log=log,
+        )
+    else:
+        cache_path = find_frame_cache(package_dir, cache_path)
+    model, config = load_frame_cache(cache_path)
+    config.output_dir = os.path.dirname(package_dir)
+    log = log or Logger(timestamps=False, quiet=False)
+
+    log.section("OFFLINE FRAME REGENERATION")
+    log(f"  Package: {package_dir}")
+    log(f"  Cache:   {cache_path}")
+    configure_frames(model, config, package_dir, log)
+    regenerate_frame_outputs(model, config, package_dir, log)
+
+    debug_dir = os.path.dirname(cache_path)
+    if os.path.isdir(debug_dir):
+        generate_validation_report(model, config, debug_dir)
+        log(f"  -> {os.path.join(debug_dir, 'validation.md')}")
+
+    log.section("OFFLINE FRAME REGENERATION COMPLETE")
+    return cache_path
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Reapply frame_overrides.csv to a cached Fusion export without "
+            "extracting or exporting meshes again."
+        )
+    )
+    parser.add_argument("package", help="Generated *_description package directory")
+    parser.add_argument(
+        "--cache",
+        default="",
+        help="Explicit debug/frame_model.json path (normally auto-detected)",
+    )
+    parser.add_argument(
+        "--snapshot",
+        default="",
+        help=(
+            "Bootstrap/rebuild the cache from an existing debug/snapshot.json "
+            "and package meshes; no Fusion API is used"
+        ),
+    )
+    args = parser.parse_args(argv)
+    try:
+        reframe_package(args.package, args.cache, snapshot_path=args.snapshot)
+    except Exception as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/xacro_export.template.toml
+++ b/xacro_export.template.toml
@@ -55,6 +55,18 @@ collision_method = "primitive"
 # Mesh resolution from Fusion: "low", "medium", "high"
 mesh_refinement = "medium"
 
+[frames]
+# "ros" is the default post-export convention:
+#   - root frame matches Fusion design world (X forward, Z up)
+#   - revolute/continuous joints rotate about their child frame's local +Z
+# Mesh vertices are never changed; visual/collision/inertia origins compensate.
+# "fusion" keeps the extracted orientations except explicit CSV overrides.
+convention = "ros"
+
+# Generated under <package>/config/.  Edit rule/post_* columns, then run
+# tools/reframe.py to regenerate descriptions without opening Fusion.
+overrides_file = "frame_overrides.csv"
+
 [ros2_control]
 # Generic mock hardware lets the exported package start controller_manager
 # immediately. Replace with your real hardware plugin when integrating


### PR DESCRIPTION
## Summary

- add cached post-export frame rebasing and CSV overrides
- fix rigid-group mesh anchoring and subassembly endpoints
- preserve frame-only and jointless exports
- update documentation, tests, and version to 3.1.0

Compatible with the nested-joint fix merged in #1.

## Tests

- `python run_tests.py`
- `python scripts/validate_examples.py examples/`
- GitHub Actions: Python 3.10, 3.11, 3.12